### PR TITLE
Fix storeId generation bug

### DIFF
--- a/src/util/store-id.ts
+++ b/src/util/store-id.ts
@@ -9,4 +9,5 @@ export const getStoreId = () => {
   searchParams.set('storeId', newAppId)
 
   window.location.search = searchParams.toString()
+  return newAppId
 }

--- a/tests/unit/store-id.test.ts
+++ b/tests/unit/store-id.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { getStoreId } from '../../src/util/store-id.js'
+
+describe('getStoreId', () => {
+  it('returns existing storeId from query string', () => {
+    const originalHref = window.location.href
+    window.history.replaceState({}, '', '?storeId=abc123')
+    const id = getStoreId()
+    expect(id).toBe('abc123')
+    window.history.replaceState({}, '', originalHref)
+  })
+
+  it('generates new id when none present', () => {
+    const originalWindow: any = globalThis.window
+    const mockWindow: any = { location: { search: '' } }
+    globalThis.window = mockWindow
+    const id = getStoreId()
+    expect(mockWindow.location.search).toBe(`storeId=${id}`)
+    globalThis.window = originalWindow
+  })
+
+  it('returns "unused" when window is undefined', () => {
+    const globalAny: any = globalThis
+    const originalWindow = globalAny.window
+    delete globalAny.window
+    const id = getStoreId()
+    expect(id).toBe('unused')
+    globalAny.window = originalWindow
+  })
+})


### PR DESCRIPTION
## Summary
- return generated store id in `getStoreId`
- add unit tests for `getStoreId`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684a07d43c1c832a901a04a79885ed17