### PR TITLE
Add copy button for chat messages

### DIFF
--- a/src/components/chat/ChatInterface/ChatInterface.test.tsx
+++ b/src/components/chat/ChatInterface/ChatInterface.test.tsx
@@ -60,4 +60,34 @@ describe('ChatInterface', () => {
     expect(screen.getByLabelText('New Chat')).toBeInTheDocument() // + button should be visible
     expect(screen.getByDisplayValue('')).toBeInTheDocument() // conversation selector
   })
+
+  it('renders copy button for chat messages', () => {
+    const mockConversations = [
+      { id: 'conv1', title: 'Test Conversation', createdAt: new Date(), updatedAt: new Date() },
+    ]
+
+    const mockMessages = [
+      {
+        id: 'msg1',
+        conversationId: 'conv1',
+        message: 'Hello world',
+        role: 'assistant',
+        createdAt: new Date(),
+      },
+    ]
+
+    mockUseQuery.mockImplementation((query: any) => {
+      if (query.label?.includes('getConversations')) return mockConversations
+      if (query.label === 'getConversationMessages:conv1') return mockMessages
+      return []
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/?conversationId=conv1']}>
+        <ChatInterface />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Copy')).toBeInTheDocument()
+  })
 })

--- a/src/components/chat/ChatInterface/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface/ChatInterface.tsx
@@ -553,7 +553,9 @@ export const ChatInterface: React.FC = () => {
 
   // Auto-scroll to bottom when messages change
   React.useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    if (messagesEndRef.current && typeof messagesEndRef.current.scrollIntoView === 'function') {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
   }, [messages])
 
   // Handle focus for mobile to show keyboard
@@ -721,6 +723,36 @@ export const ChatInterface: React.FC = () => {
                           ) : (
                             <div className='text-sm text-gray-900'>{message.message}</div>
                           ))}
+
+                        {message.message && message.message.trim() && (
+                          <div className='mt-2 flex justify-end'>
+                            <button
+                              onClick={() =>
+                                navigator.clipboard
+                                  .writeText(message.message as string)
+                                  .catch(err => {
+                                    console.error('Failed to copy message', err)
+                                  })
+                              }
+                              className='flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600'
+                            >
+                              <svg
+                                className='w-3 h-3'
+                                fill='none'
+                                stroke='currentColor'
+                                viewBox='0 0 24 24'
+                              >
+                                <path
+                                  strokeLinecap='round'
+                                  strokeLinejoin='round'
+                                  strokeWidth={2}
+                                  d='M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-4 8h4a2 2 0 002-2v-4m-6 6L16 8'
+                                />
+                              </svg>
+                              <span>Copy</span>
+                            </button>
+                          </div>
+                        )}
                       </div>
                     )
                   })}


### PR DESCRIPTION
## Summary
- add auto-scroll guard for jsdom env
- add copy-to-clipboard button for each chat message
- test copy button appears

## Testing
- `pnpm lint-all`
- `pnpm test`
- `CI=true pnpm test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876bb53d9d8832abc27a399cd9226e9