### PR TITLE
Add Team tab in project view

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -112,7 +112,7 @@ export const App: React.FC = () => (
                   }
                 />
                 <Route
-                  path={ROUTES.WORKERS}
+                  path={ROUTES.TEAM}
                   element={
                     <Layout>
                       <ErrorBoundary>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -22,8 +22,8 @@ export const Navigation: React.FC = () => {
     if (path === ROUTES.TASKS) {
       return location.pathname === ROUTES.TASKS
     }
-    if (path === ROUTES.WORKERS) {
-      return location.pathname === ROUTES.WORKERS
+    if (path === ROUTES.TEAM) {
+      return location.pathname === ROUTES.TEAM
     }
     if (path === ROUTES.DOCUMENTS) {
       return (
@@ -60,14 +60,14 @@ export const Navigation: React.FC = () => {
               Tasks
             </Link>
             <Link
-              to={preserveStoreIdInUrl(ROUTES.WORKERS)}
+              to={preserveStoreIdInUrl(ROUTES.TEAM)}
               className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
-                isActive(ROUTES.WORKERS)
+                isActive(ROUTES.TEAM)
                   ? 'border-blue-500 text-gray-900'
                   : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
               }`}
             >
-              Workers
+              Team
             </Link>
             <Link
               to={preserveStoreIdInUrl(ROUTES.DOCUMENTS)}

--- a/src/components/projects/ProjectCard/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard/ProjectCard.tsx
@@ -52,7 +52,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project, onClick }) =>
 
       {assignedWorkers.length > 0 && (
         <div className='mb-3'>
-          <div className='text-xs text-gray-500 mb-1'>Assigned Workers:</div>
+          <div className='text-xs text-gray-500 mb-1'>Assigned Team:</div>
           <div className='flex flex-wrap gap-1'>
             {assignedWorkers.slice(0, 3).map(worker => (
               <span
@@ -75,7 +75,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project, onClick }) =>
       <div className='text-sm text-gray-500'>
         <p>Created: {formatDate(project.createdAt)}</p>
         <p>Updated: {formatDate(project.updatedAt)}</p>
-        <p>Workers: {assignedWorkers.length > 0 ? assignedWorkers.length : 'None assigned'}</p>
+        <p>Team: {assignedWorkers.length > 0 ? assignedWorkers.length : 'None assigned'}</p>
       </div>
     </div>
   )

--- a/src/components/projects/ProjectWorkspace/ProjectWorkspace.test.tsx
+++ b/src/components/projects/ProjectWorkspace/ProjectWorkspace.test.tsx
@@ -7,6 +7,7 @@ import {
   createMockColumn,
   createMockTask,
 } from '../../../../tests/test-utils.js'
+import type { Worker } from '../../../livestore/schema.js'
 
 // Hoisted mocks
 const { mockUseQuery, mockStore, mockUseParams } = vi.hoisted(() => {
@@ -67,6 +68,19 @@ describe('ProjectWorkspace', () => {
   })
   const mockColumns = [createMockColumn({ id: 'col-1', name: 'Todo' })]
   const mockTasks = [createMockTask({ id: 'task-1', columnId: 'col-1', title: 'Test Task' })]
+  const mockWorkers = [
+    {
+      id: 'worker-1',
+      name: 'Worker One',
+      roleDescription: null,
+      systemPrompt: 'test',
+      avatar: '🤖',
+      defaultModel: 'claude-3-5-sonnet-latest',
+      createdAt: new Date('2023-01-01'),
+      updatedAt: new Date('2023-01-01'),
+      isActive: true,
+    },
+  ] as unknown as Worker[]
 
   beforeEach(() => {
     mockUseParams.mockReturnValue({ projectId: 'test-project' })
@@ -85,7 +99,13 @@ describe('ProjectWorkspace', () => {
       } else if (callCount === 3) {
         return mockTasks // Third call is for tasks
       } else if (callCount === 4) {
-        return [] // Fourth call is for documents (empty for now)
+        return [] // Fourth call is for document-project links
+      } else if (callCount === 5) {
+        return [] // Fifth call is for documents
+      } else if (callCount === 6) {
+        return [] // Sixth call is for project workers (none)
+      } else if (callCount === 7) {
+        return mockWorkers // Seventh call is for all workers
       }
       return []
     })
@@ -138,6 +158,17 @@ describe('ProjectWorkspace', () => {
     expect(screen.getByText('No documents yet')).toBeInTheDocument()
     expect(screen.getByText('Create your first document to get started')).toBeInTheDocument()
     expect(screen.getAllByText('Create Document')).toHaveLength(2) // Header button + empty state button
+  })
+
+  it('should show empty state when team tab is active with no assignments', () => {
+    render(<ProjectWorkspace />)
+
+    const teamTab = screen.getByRole('button', { name: 'Team' })
+    act(() => {
+      teamTab.click()
+    })
+
+    expect(screen.getByText('No team members assigned')).toBeInTheDocument()
   })
 
   it('should handle missing projectId', () => {

--- a/src/components/projects/ProjectWorkspace/ProjectWorkspace.tsx
+++ b/src/components/projects/ProjectWorkspace/ProjectWorkspace.tsx
@@ -8,8 +8,10 @@ import {
   getProjectTasks$,
   getAllDocuments$,
   getDocumentProjectsByProject$,
+  getProjectWorkers$,
+  getWorkers$,
 } from '../../../livestore/queries.js'
-import type { Task, Document } from '../../../livestore/schema.js'
+import type { Task, Document, Worker } from '../../../livestore/schema.js'
 import { events } from '../../../livestore/schema.js'
 import { ProjectProvider, useProject } from '../../../contexts/ProjectContext.js'
 import { KanbanBoard } from '../../tasks/kanban/KanbanBoard.js'
@@ -17,6 +19,7 @@ import { TaskModal } from '../../tasks/TaskModal/TaskModal.js'
 import { DocumentCreateModal } from '../../documents/DocumentCreateModal/DocumentCreateModal.js'
 import { AddExistingDocumentModal } from '../../documents/AddExistingDocumentModal/AddExistingDocumentModal.js'
 import { LoadingState } from '../../ui/LoadingState.js'
+import { WorkerCard } from '../../workers/WorkerCard/WorkerCard.js'
 
 // Component for the actual workspace content
 const ProjectWorkspaceContent: React.FC = () => {
@@ -29,7 +32,7 @@ const ProjectWorkspaceContent: React.FC = () => {
   } | null>(null)
   const [dragOverAddCard, setDragOverAddCard] = useState<string | null>(null)
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
-  const [activeTab, setActiveTab] = useState<'tasks' | 'documents'>('tasks')
+  const [activeTab, setActiveTab] = useState<'tasks' | 'documents' | 'team'>('tasks')
   const [isDocumentModalOpen, setIsDocumentModalOpen] = useState(false)
   const [isAddExistingDocumentModalOpen, setIsAddExistingDocumentModalOpen] = useState(false)
 
@@ -49,6 +52,11 @@ const ProjectWorkspaceContent: React.FC = () => {
   const allDocuments = useQuery(getAllDocuments$) ?? []
   const documentIds = new Set(documentProjects.map(dp => dp.documentId))
   const documents = allDocuments.filter(doc => documentIds.has(doc.id)) as Document[]
+
+  // Get workers assigned to this project
+  const workerProjects = useQuery(getProjectWorkers$(projectId)) ?? []
+  const allWorkers = useQuery(getWorkers$) ?? []
+  const team: Worker[] = allWorkers.filter(w => workerProjects.some(wp => wp.workerId === w.id))
 
   // Group tasks by column
   const tasksByColumn = (tasks || []).reduce((acc: Record<string, Task[]>, task: Task) => {
@@ -330,6 +338,16 @@ const ProjectWorkspaceContent: React.FC = () => {
             Tasks
           </button>
           <button
+            onClick={() => setActiveTab('team')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === 'team'
+                ? 'border-blue-500 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+            }`}
+          >
+            Team
+          </button>
+          <button
             onClick={() => setActiveTab('documents')}
             className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
               activeTab === 'documents'
@@ -360,6 +378,22 @@ const ProjectWorkspaceContent: React.FC = () => {
             />
             <TaskModal taskId={selectedTaskId} onClose={handleModalClose} />
           </>
+        )}
+
+        {activeTab === 'team' && (
+          <div className='p-6'>
+            {team.length > 0 ? (
+              <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6'>
+                {team.map(worker => (
+                  <WorkerCard key={worker.id} worker={worker} />
+                ))}
+              </div>
+            ) : (
+              <div className='flex items-center justify-center h-64 text-gray-500'>
+                <p>No team members assigned</p>
+              </div>
+            )}
+          </div>
         )}
 
         {activeTab === 'documents' && (

--- a/src/components/workers/WorkersPage.tsx
+++ b/src/components/workers/WorkersPage.tsx
@@ -15,7 +15,7 @@ export const WorkersPage: React.FC = () => {
         <div className='border-b border-gray-200 bg-white px-6 py-4'>
           <div className='flex justify-between items-center mb-4'>
             <div>
-              <h1 className='text-xl font-semibold text-gray-900 mb-1'>Workers</h1>
+              <h1 className='text-xl font-semibold text-gray-900 mb-1'>Team</h1>
               <p className='text-gray-600 text-sm'>Manage your AI assistants</p>
             </div>
             <button
@@ -30,7 +30,7 @@ export const WorkersPage: React.FC = () => {
         {/* Empty State Content */}
         <div className='flex-1 bg-gray-50 flex flex-col items-center justify-center p-8'>
           <div className='text-center'>
-            <h2 className='text-xl font-semibold text-gray-600 mb-4'>No workers found</h2>
+            <h2 className='text-xl font-semibold text-gray-600 mb-4'>No team members found</h2>
             <p className='text-gray-500 mb-6'>
               Create your first worker to get started with AI assistance.
             </p>
@@ -54,7 +54,7 @@ export const WorkersPage: React.FC = () => {
       <div className='border-b border-gray-200 bg-white px-6 py-4'>
         <div className='flex justify-between items-center mb-4'>
           <div>
-            <h1 className='text-xl font-semibold text-gray-900 mb-1'>Workers</h1>
+            <h1 className='text-xl font-semibold text-gray-900 mb-1'>Team</h1>
             <p className='text-gray-600 text-sm'>Manage your AI assistants</p>
           </div>
           <button

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -6,7 +6,7 @@ export const ROUTES = {
   HOME: '/',
   PROJECTS: '/projects',
   TASKS: '/tasks',
-  WORKERS: '/workers',
+  TEAM: '/team',
   DOCUMENTS: '/documents',
   DOCUMENT: '/document/:documentId',
   PROJECT: '/project/:projectId',


### PR DESCRIPTION
Closes #76 

## Summary
- rename Workers routes and navigation to Team
- update Workers page headings to Team
- show Team tab in ProjectWorkspace with assigned workers
- adjust ProjectCard labels to "Team"
- update tests for new Team tab

## Testing
- `pnpm lint-all`
- `pnpm test`
- `CI=true pnpm test:e2e` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876f1b7ff30832aadba36746471b490