### PR TITLE
feat(chat): context-aware new conversations

### DIFF
--- a/packages/web/src/components/chat/ChatInterface/ChatInterface.test.tsx
+++ b/packages/web/src/components/chat/ChatInterface/ChatInterface.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { ChatInterface } from './ChatInterface.js'
@@ -16,8 +16,9 @@ vi.mock('@livestore/react', () => ({
 }))
 
 // Import after mocking
-import { useQuery } from '@livestore/react'
+import { useQuery, useStore } from '@livestore/react'
 const mockUseQuery = useQuery as ReturnType<typeof vi.fn>
+const mockUseStore = useStore as ReturnType<typeof vi.fn>
 
 describe('ChatInterface', () => {
   beforeEach(() => {
@@ -56,9 +57,89 @@ describe('ChatInterface', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Chat')).toBeInTheDocument()
+    expect(screen.getByText('Core AI')).toBeInTheDocument()
     expect(screen.getByLabelText('New Chat')).toBeInTheDocument() // + button should be visible
     expect(screen.getByDisplayValue('')).toBeInTheDocument() // conversation selector
+  })
+
+  it('filters conversations by current worker', () => {
+    const mockConversations = [
+      {
+        id: 'conv1',
+        title: 'Chat with Worker One',
+        workerId: 'worker1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'conv2',
+        title: 'Chat with Worker Two',
+        workerId: 'worker2',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]
+
+    const mockWorkers: Record<string, any[]> = {
+      'getWorkerById:worker1': [{ id: 'worker1', name: 'Worker One', defaultModel: 'gpt' }],
+      'getWorkerById:worker2': [{ id: 'worker2', name: 'Worker Two', defaultModel: 'gpt' }],
+    }
+
+    mockUseQuery.mockImplementation((query: any) => {
+      if (query.label?.includes('getConversations')) return mockConversations
+      if (mockWorkers[query.label as string]) return mockWorkers[query.label as string]
+      return []
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/?conversationId=conv1']}>
+        <ChatInterface />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByRole('option', { name: 'Chat with Worker Two' })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Chat with Worker One' })).toBeInTheDocument()
+  })
+
+  it('creates new conversation with current worker when plus clicked', () => {
+    const mockConversations = [
+      {
+        id: 'conv1',
+        title: 'Chat with Worker One',
+        workerId: 'worker1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]
+
+    const mockWorkers: Record<string, any[]> = {
+      'getWorkerById:worker1': [{ id: 'worker1', name: 'Worker One', defaultModel: 'gpt' }],
+    }
+
+    mockUseQuery.mockImplementation((query: any) => {
+      if (query.label?.includes('getConversations')) return mockConversations
+      if (mockWorkers[query.label as string]) return mockWorkers[query.label as string]
+      return []
+    })
+
+    const commitMock = vi.fn()
+    mockUseStore.mockReturnValue({
+      store: { commit: commitMock, subscribe: vi.fn(() => vi.fn()) },
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/?conversationId=conv1']}>
+        <ChatInterface />
+      </MemoryRouter>
+    )
+
+    const plusButton = screen.getByLabelText('New Chat')
+    fireEvent.click(plusButton)
+
+    expect(commitMock).toHaveBeenCalled()
+    const event = commitMock.mock.calls[0]?.[0] as any
+    expect(event.args.workerId).toBe('worker1')
+    expect(event.args.title).toContain('Worker One')
   })
 
   it('renders copy button for chat messages', () => {


### PR DESCRIPTION
## Summary
- scope conversation list to selected worker or core AI
- default new chats to the current worker, labeling core AI when none
- add tests for worker-scoped chats

## Testing
- `pnpm lint-all`
- `pnpm test`
- `CI=true pnpm test:e2e` *(fails: `playwright test` exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_689a8743adb4832a96605a9e924a4e3a