### PR TITLE
fix: prevent auto worker name regeneration

### DIFF
--- a/packages/web/src/components/workers/CreateWorkerModal/CreateWorkerModal.test.tsx
+++ b/packages/web/src/components/workers/CreateWorkerModal/CreateWorkerModal.test.tsx
@@ -83,8 +83,10 @@ describe('CreateWorkerModal', () => {
     const submitButton = screen.getByRole('button', { name: 'Create Worker' })
 
     // Clear the auto-generated name and system prompt
-    fireEvent.change(nameInput, { target: { value: '   ' } }) // Just spaces
-    fireEvent.change(systemPromptInput, { target: { value: '   ' } }) // Just spaces
+    fireEvent.change(nameInput, { target: { value: '' } })
+    fireEvent.change(systemPromptInput, { target: { value: '' } })
+
+    expect(nameInput).toHaveValue('')
 
     fireEvent.click(submitButton)
 

--- a/packages/web/src/components/workers/CreateWorkerModal/CreateWorkerModal.tsx
+++ b/packages/web/src/components/workers/CreateWorkerModal/CreateWorkerModal.tsx
@@ -24,10 +24,10 @@ export const CreateWorkerModal: React.FC<CreateWorkerModalProps> = ({ isOpen, on
 
   // Generate random name when modal opens
   useEffect(() => {
-    if (isOpen && !name) {
+    if (isOpen) {
       setName(generateRandomWorkerName())
     }
-  }, [isOpen, name])
+  }, [isOpen])
 
   const validateForm = () => {
     const newErrors: { name?: string; systemPrompt?: string } = {}


### PR DESCRIPTION
## Summary
- avoid regenerating random worker name when the field is cleared
- test that blanking the generated name keeps it empty and requires manual input

## Testing
- `pnpm lint-all`
- `pnpm test`
- `CI=true pnpm test:e2e` *(fails: browser executable missing, Playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689a86da6cf4832a9daf981d5e36818a