### PR TITLE
fix: prevent duplicate user turns in agent history

### DIFF
--- a/docs/plans/018-llm-message-duplication.md
+++ b/docs/plans/018-llm-message-duplication.md
@@ -1,0 +1,41 @@
+# Plan: Fix duplicate user messages sent to server LLM processor
+
+## Summary
+
+- LLM agent running on the server currently receives every user chat message twice, leading to duplicate reasoning chains and redundant tool execution.
+- Root cause: the agentic loop is initialized with a conversation history that already contains the newest user message, and the loop immediately appends the same message again before calling the provider. This results in duplicated user turns being sent to the LLM.
+- Goal: ensure each user turn appears exactly once in the outbound history by adjusting history construction, covering the behavior with tests, and adding safeguards that detect regressions.
+
+## Current Behavior & Findings
+
+1. When a new user chat message arrives, `EventProcessor.runAgenticLoop` loads the full ordered chat history for that conversation and converts it to `LLMMessage` entries before instantiating the `AgenticLoop` (`event-processor.ts` lines 772-889). The most recent user message (the one currently being processed) is included in this history.
+2. Inside `AgenticLoop.run`, the implementation unconditionally pushes the user input onto the `ConversationHistory` prior to the first Braintrust call (`agentic-loop.ts` lines 36-70). Because the same message was already part of `initialHistory`, the history now contains two identical user turns, and both copies are sent to the provider on every iteration.
+3. The duplication explains the observed "double inputs" without requiring duplicate LiveStore events; processed-message tracking continues to work as designed, so only the outbound payload is affected.
+
+## Proposed Changes
+
+1. **Build a pre-LLM history that excludes the live user message.**
+   - When `runAgenticLoop` builds `chatHistory`, slice off the trailing entry when it matches the message currently being processed (by `id`).
+   - Generate `rawHistory` and sanitize it from this trimmed list so the `AgenticLoop` starts with past turns only.
+2. **Cover with automated tests.**
+   - Extend or add a unit test around the agentic loop (e.g., a focused test that feeds a fake history and asserts the provider receives the correct sequence) to ensure only one copy of the latest user turn is emitted.
+   - Consider adding a regression test in `event-processor` (using spies/mocks) that verifies a single `LLMMessage` per user input is passed into the provider.
+3. **Add lightweight instrumentation to detect future regressions.**
+   - Emit a debug log (or optional metric) when duplicate consecutive user messages are detected in the constructed history before calling the provider; guard it so it does not spam logs, but it will help catch similar issues in the future.
+4. **Document the invariant.**
+   - Update inline comments near the history construction call site to clarify why the current message is intentionally excluded.
+
+## Testing Strategy
+
+- Unit tests for the agentic loop history handling.
+- Event processor tests exercising `runAgenticLoop` with mocked Braintrust provider to confirm single delivery.
+- Smoke verification in development environment by sending a user message and inspecting logs/Braintrust payload (manual sanity check after automated tests pass).
+
+## Risks & Mitigations
+
+- **Risk:** Accidentally trimming non-user messages if ordering assumptions break. _Mitigation:_ Guard the slice with both `id` match and `role === 'user'` check, and cover with tests featuring assistant/tool messages after the user turn.
+- **Risk:** Future refactors to conversation history might reintroduce duplicates. _Mitigation:_ Keep the regression test in place and add the proposed instrumentation.
+
+## Open Questions
+
+- Do we need to backfill or clean up any past LLM outputs that were generated from duplicated inputs? (Likely out of scope for this fix, but worth confirming with stakeholders.)

--- a/packages/server/src/services/event-processor-conversation-history.test.ts
+++ b/packages/server/src/services/event-processor-conversation-history.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventProcessor } from './event-processor.js'
+import type { ChatMessage, LLMMessage } from './agentic-loop/types.js'
+
+const { createLoggerMock, loggerContainer } = vi.hoisted(() => {
+  const factory = () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })
+
+  return {
+    createLoggerMock: factory,
+    loggerContainer: { logger: null as ReturnType<typeof factory> | null },
+  }
+})
+
+vi.mock('../utils/logger.js', () => {
+  loggerContainer.logger = createLoggerMock()
+  return {
+    logger: loggerContainer.logger,
+    storeLogger: vi.fn(() => createLoggerMock()),
+    createContextLogger: vi.fn(() => createLoggerMock()),
+  }
+})
+
+vi.mock('./processed-message-tracker.js', () => ({
+  ProcessedMessageTracker: vi.fn(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    isProcessed: vi.fn(),
+    markProcessed: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+describe('EventProcessor conversation history builder', () => {
+  let eventProcessor: EventProcessor
+
+  beforeEach(() => {
+    process.env.BRAINTRUST_API_KEY = 'test-key'
+    process.env.BRAINTRUST_PROJECT_ID = 'test-project'
+    eventProcessor = new EventProcessor({} as any)
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    eventProcessor.stopAll()
+    delete process.env.BRAINTRUST_API_KEY
+    delete process.env.BRAINTRUST_PROJECT_ID
+    vi.clearAllMocks()
+  })
+
+  it('excludes the live user message from the conversation history', () => {
+    const userMessage: ChatMessage = {
+      id: 'user-1',
+      conversationId: 'conv-1',
+      role: 'user',
+      message: 'Hello there',
+      createdAt: new Date('2024-01-01T00:00:10Z'),
+    }
+
+    const chatHistory: ChatMessage[] = [
+      {
+        id: 'system-1',
+        conversationId: 'conv-1',
+        role: 'system',
+        message: 'You are a helpful assistant',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+      },
+      userMessage,
+    ]
+
+    const conversationHistory = (eventProcessor as any).buildConversationHistory(
+      chatHistory,
+      userMessage
+    ) as LLMMessage[]
+
+    expect(conversationHistory).toHaveLength(1)
+    expect(conversationHistory[0]).toMatchObject({
+      role: 'system',
+      content: 'You are a helpful assistant',
+    })
+    expect(
+      conversationHistory.some(
+        (message: LLMMessage) => message.role === 'user' && message.content === userMessage.message
+      )
+    ).toBe(false)
+    expect(loggerContainer.logger!.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'conv-1',
+        userMessageId: 'user-1',
+      }),
+      'Trimming current user message from conversation history before LLM call'
+    )
+  })
+
+  it('keeps historical messages when the latest entry is not the live user message', () => {
+    const userMessage: ChatMessage = {
+      id: 'user-2',
+      conversationId: 'conv-1',
+      role: 'user',
+      message: 'New input',
+      createdAt: new Date('2024-01-01T00:01:00Z'),
+    }
+
+    const chatHistory: ChatMessage[] = [
+      {
+        id: 'system-1',
+        conversationId: 'conv-1',
+        role: 'system',
+        message: 'You are a helpful assistant',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+      },
+      {
+        id: 'user-previous',
+        conversationId: 'conv-1',
+        role: 'user',
+        message: 'Previous input',
+        createdAt: new Date('2024-01-01T00:00:30Z'),
+      },
+      {
+        id: 'assistant-1',
+        conversationId: 'conv-1',
+        role: 'assistant',
+        message: 'Assistant response',
+        createdAt: new Date('2024-01-01T00:00:40Z'),
+      },
+    ]
+
+    const conversationHistory = (eventProcessor as any).buildConversationHistory(
+      chatHistory,
+      userMessage
+    ) as LLMMessage[]
+
+    expect(conversationHistory).toHaveLength(3)
+    expect(conversationHistory.map(({ role, content }: LLMMessage) => [role, content])).toEqual([
+      ['system', 'You are a helpful assistant'],
+      ['user', 'Previous input'],
+      ['assistant', 'Assistant response'],
+    ])
+    expect(loggerContainer.logger!.debug).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning when duplicate consecutive user messages remain', () => {
+    const userMessage: ChatMessage = {
+      id: 'user-latest',
+      conversationId: 'conv-1',
+      role: 'user',
+      message: 'Latest input',
+      createdAt: new Date('2024-01-01T00:02:00Z'),
+    }
+
+    const chatHistory: ChatMessage[] = [
+      {
+        id: 'user-1',
+        conversationId: 'conv-1',
+        role: 'user',
+        message: 'Repeated input',
+        createdAt: new Date('2024-01-01T00:00:10Z'),
+      },
+      {
+        id: 'user-2',
+        conversationId: 'conv-1',
+        role: 'user',
+        message: 'Repeated input',
+        createdAt: new Date('2024-01-01T00:00:20Z'),
+      },
+    ]
+
+    const conversationHistory = (eventProcessor as any).buildConversationHistory(
+      chatHistory,
+      userMessage
+    ) as LLMMessage[]
+
+    expect(conversationHistory).toHaveLength(2)
+    expect(
+      conversationHistory
+        .filter((message: LLMMessage) => message.role === 'user')
+        .map((message: LLMMessage) => message.content)
+    ).toEqual(['Repeated input', 'Repeated input'])
+    expect(loggerContainer.logger!.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'conv-1',
+        userMessageId: 'user-latest',
+        duplicates: expect.arrayContaining([
+          expect.objectContaining({ preview: 'Repeated input' }),
+        ]),
+      }),
+      'Detected duplicate consecutive user messages in conversation history'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- ensure the event processor trims the live user message before starting the agentic loop and add duplicate-detection logging
- introduce a dedicated helper for building sanitized conversation history and cover it with focused unit tests

## Testing
- pnpm lint-all
- pnpm --filter @work-squared/server test

------
https://chatgpt.com/codex/tasks/task_e_68e916a08074832aa7dc9954703923f4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate user turns by excluding the live user message from agent history, adds duplicate-detection logging, and covers behavior with focused tests.
> 
> - **Backend (server)**:
>   - **Conversation history construction**:
>     - Introduces `buildConversationHistory` in `packages/server/src/services/event-processor.ts` to exclude the live `user` message, sanitize tool calls, and warn on duplicate consecutive `user` messages.
>   - Wires `runAgenticLoop` to use `buildConversationHistory` instead of inlined history building.
> - **Tests**:
>   - Adds `packages/server/src/services/event-processor-conversation-history.test.ts` covering trimming of the current `user` message, non-trim scenarios, and duplicate-warning logging.
> - **Docs**:
>   - Adds `docs/plans/018-llm-message-duplication.md` outlining the issue, approach, tests, and risks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e12139be39d5f4da99da1702959176af4a0ef21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->