### PR TITLE
Add GitHub CLI documentation and fix inconsistencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 pnpm lint-all          # Runs lint, format, AND typecheck in one command
 pnpm test              # Runs unit tests
-CI=true pnpm test:e2e  # Runs E2E tests
+CI=true pnpm test:e2e  # Runs E2E tests (required before committing)
 ```
 
 `lint-all` replaces:
@@ -46,8 +46,8 @@ pnpm lint-all      # ✅ Use this! Runs lint, format, and typecheck
 
 # Testing
 pnpm test          # Unit tests
-pnpm test:e2e      # E2E tests
-CI=true pnpm test:e2e  # Verify E2E tests work (for Claude)
+pnpm test:e2e      # E2E tests (watch mode for development)
+CI=true pnpm test:e2e  # E2E tests in CI mode (required before committing)
 
 # Building
 pnpm --filter @work-squared/web build    # Build web package
@@ -89,7 +89,7 @@ Work Squared is a real-time collaborative web application built as a monorepo wi
 
 1. Review requirements thoroughly
 2. Ask clarifying questions
-3. Create descriptive branch (e.g., `feature/documents-tab`)
+3. Create descriptive branch with your username prefix (e.g., `jessmartin/add-feature-name`)
 
 ### While Developing
 
@@ -108,9 +108,11 @@ CI=true pnpm test:e2e  # Run E2E tests
 ### Creating a PR
 
 1. Write clear commit messages
-2. Open PR with detailed description
-3. Run `gh pr checks --watch` and wait for all checks (up to 10 minutes)
-4. Fix any issues (including neutral BugBot feedback)
+2. Push your branch to GitHub
+3. Create PR: `gh pr create --title "Title" --body "Description"` (or use GitHub web UI)
+4. Monitor checks: `gh pr checks --watch` and wait for all checks (up to 10 minutes)
+5. Check for feedback: `gh pr view <number> --comments` to see reviews and comments
+6. Fix any issues (including neutral BugBot feedback)
 
 ## GitHub CLI (`gh`) Commands
 
@@ -134,8 +136,9 @@ gh pr list                       # List all open PRs
 gh pr list --author @me          # List your PRs
 gh pr list --state merged        # List merged PRs
 
-# Create PR (see "Creating a PR" section for full workflow)
+# Create PR
 gh pr create --title "Title" --body "Description"
+gh pr create --web   # Open browser to create PR with full editor
 ```
 
 ### Issue Commands
@@ -390,6 +393,14 @@ const emptySetup = (store: Store) => {
 
 ## Deployment
 
-Deployments happen automatically when you push to the main branch.
+Deployments happen automatically via GitHub Actions when PRs are merged to the main branch.
 
-1. Deploy worker + assets to Cloudflare `pnpm --filter @work-squared/worker deploy`
+### Manual Deployment (if needed)
+
+Use these commands only when you need to deploy manually outside the normal CI/CD pipeline:
+
+```bash
+pnpm --filter @work-squared/auth-worker run deploy  # Deploy auth worker to Cloudflare
+pnpm --filter @work-squared/worker run deploy       # Deploy sync server to Cloudflare
+pnpm --filter @work-squared/web run deploy          # Deploy web app to Cloudflare Pages
+```


### PR DESCRIPTION
## Summary

- Add comprehensive GitHub CLI (`gh`) command documentation to CLAUDE.md
- Fix multiple documentation inconsistencies throughout the file

## Changes

### First Commit: Add GitHub CLI Documentation
- Document `gh pr` commands for viewing, checking status, listing, and creating PRs
- Document `gh issue` commands for managing issues
- Provide common workflows with practical examples using PR #272
- Add best practices for CI/CD monitoring

### Second Commit: Fix Documentation Inconsistencies
1. **Branch naming**: Update example from `feature/documents-tab` to `jessmartin/add-feature-name` to match actual convention
2. **Creating PR workflow**: Expand from 4 steps to 6 steps with explicit `gh` command usage and feedback checking
3. **Test commands**: Clarify difference between `pnpm test:e2e` (watch mode) and `CI=true pnpm test:e2e` (CI mode)
4. **PR creation**: Add `gh pr create --web` option for full editor experience
5. **Deployment**: Clarify that deployments are automatic via GitHub Actions, manual commands only for exceptions
6. **Remove duplicate deployment command** at end of file

## Testing

- [x] Verified `gh` commands work with PR #272
- [x] All command examples tested in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances `CLAUDE.md` with `gh` CLI documentation, updates workflow/testing guidance, and clarifies CI-based deployments with optional manual commands.
> 
> - **Documentation**
>   - Add comprehensive `gh` CLI sections: PR commands, issue commands, common workflows, and notes.
> - **Workflow**
>   - Update branch naming to `username/feature` (e.g., `jessmartin/add-feature-name`).
>   - Expand PR creation steps with `gh pr create`, status monitoring, and feedback review.
> - **Testing**
>   - Clarify E2E usage: `pnpm test:e2e` (watch) vs `CI=true pnpm test:e2e` (CI mode; required before committing).
> - **Deployment**
>   - Specify automatic deployments via GitHub Actions on merge to `main`.
>   - Add manual deployment commands for `@work-squared/auth-worker`, `@work-squared/worker`, and `@work-squared/web`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62bd6c15516d0f5493601f6c593f85508f8994e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->