### PR TITLE
Implement backlog activation in Life Category view

### DIFF
--- a/docs/plans/023-life-squared-epic/README.md
+++ b/docs/plans/023-life-squared-epic/README.md
@@ -44,41 +44,39 @@ This epic plan provides an overview of all user stories organized across three s
 
 **Story Count**: 12 stories (11 completed, 1 deferred)
 
-### Phase 2: Life Category Planning - **Early Stage**
+### Phase 2: Life Category Planning - **In Progress**
 
 [View Phase 2 Document](phase-2-life-category-view.md)
 
 **Purpose**: Build the project planning system with structured 4-stage development and backlog management.
 
-**Completed** (PRs #246, #250):
+**Completed** (PRs #246, #250, #252, #254, #266, #267, #268, #271):
 
-- ✅ Three main tabs (Planning, Active, Completed)
-- ✅ Smart default tab selection
-- ✅ Three Planning sub-tabs (Project Creation, Project Plans, Backlog)
-- ✅ Stage 1 (Identified): Title, description
-- ✅ Stage 2 (Scoped): Objectives, deadlines, archetype, traits
+- ✅ Planning/Active/Completed tab set with smart defaults
+- ✅ Project Creation Stages 1-3 (idea capture → scoping → task planning via workspace)
+- ✅ Cover image uploads backed by Cloudflare R2
+- ✅ Stage 4 backlog pipeline with drag-to-reorder prioritization
+- ✅ Activate backlog projects directly into Active tab with confirmation flow
+- ✅ Project Plans sub-tab for resuming in-progress plans (Stages 1-3)
+- ✅ Category advisors auto-create and auto-select in Life Category view
+- ✅ Navigation context attached to every LLM message for advisor awareness
 
-**In Progress** (PR #252):
+**Outstanding / Next Up**:
 
-- 🔄 Cover image upload to Cloudflare R2
-
-**Remaining Work**:
-
-- AI-generated cover images
-- Stage 3 (Task planning integration)
-- Stage 4 (Priority ranking and backlog placement)
-- Move completed plans to Backlog
-- Project Plans sub-tab (view/resume in-progress plans)
-- Backlog sub-tab (priority management, activation)
+- AI-generated cover images (Story 2.3)
+- Project Plans card visual polish + idle indicators once design lands (Stories 3.3, 3.5)
+- Auto-select advisor when entering planning Stage 3 workspace (Story 3.9)
+- Backlog search/filter (Story 4.5 – deferred / nice-to-have)
 
 **Key Features Implemented**:
 
 - Container/Presenter component architecture
 - LiveStore event-driven state management
-- Progressive planning workflow (Stages 1-2)
-- Archetype auto-suggestion based on traits
+- Progressive planning workflow (Stages 1-4) with backlog priority ordering
+- Archetype auto-suggestion based on traits and category AI advisor guidance
+- Context-aware AI assistance via navigation-aware messaging
 
-**Story Count**: 20 stories (5 completed, 1 in progress, 14 remaining)
+**Story Count**: 24 stories (18 completed, 1 deferred, 5 remaining)
 
 ### Phase 3: Active Projects, Completion & Task Management (35 stories)
 

--- a/docs/plans/023-life-squared-epic/phase-2-life-category-view.md
+++ b/docs/plans/023-life-squared-epic/phase-2-life-category-view.md
@@ -7,27 +7,27 @@ This phase introduces the Planning tab with three sub-tabs (Project Creation, Pr
 ## Progress Overview
 
 - ✅ **Section 1: Planning Tab Structure & Navigation** (Stories 1.1-1.3) - COMPLETED in PR #246 (merged 2025-10-17)
-- 🔄 **Section 2: Project Creation Sub-Tab** (Stories 2.1-2.7) - IN PROGRESS
+- 🔄 **Section 2: Project Creation Sub-Tab** (Stories 2.1-2.7) - IN PROGRESS (AI cover outstanding)
   - ✅ Story 2.1 (Stage 1) - COMPLETED in PR #250 (merged 2025-10-17)
   - ✅ Story 2.2 (Cover Upload) - COMPLETED in PR #252 (merged 2025-10-21)
   - ⏸️ Story 2.3 (AI Cover) - NOT STARTED
   - ✅ Story 2.4 (Stage 2) - COMPLETED in PR #250 (merged 2025-10-17)
   - ✅ Story 2.5 (Stage 3) - COMPLETED in PR #254 (merged 2025-10-21)
-  - ⏸️ Story 2.6 (Stage 4) - NOT STARTED
-  - ⏸️ Story 2.7 (Move to Backlog) - NOT STARTED
+  - ✅ Story 2.6 (Stage 4) - COMPLETED in PRs #254, #267 (merged 2025-10-21)
+  - ✅ Story 2.7 (Move to Backlog) - COMPLETED in PR #254 (merged 2025-10-21)
 - 🔄 **Section 3: Project Plans Sub-Tab** (Stories 3.1-3.9) - PARTIALLY COMPLETE
   - ✅ Story 3.1 (Display plans) - COMPLETED in PRs #250, #254
   - ✅ Story 3.2 (Resume planning) - COMPLETED in PRs #250, #254
   - ⏸️ Story 3.3 (Card visuals) - NEEDS DESIGN
   - ✅ Story 3.4 (Archive/delete) - COMPLETED (existing functionality)
   - ⏸️ Story 3.5 (Idle indicators) - NEEDS DESIGN
-  - ⏸️ Story 3.6 (Dynamic routing context) - NOT STARTED
-  - ⏸️ Story 3.7 (Category advisors) - NOT STARTED
-  - ⏸️ Story 3.8 (Auto-select in category) - NOT STARTED
+  - ✅ Story 3.6 (Dynamic routing context) - COMPLETED in PR #268 (merged 2025-10-21)
+  - ✅ Story 3.7 (Category advisors) - COMPLETED in PR #266 (merged 2025-10-21)
+  - ✅ Story 3.8 (Auto-select in category) - COMPLETED in PR #266 (merged 2025-10-21)
   - ⏸️ Story 3.9 (Auto-select in planning) - NOT STARTED
 - 🔄 **Section 4: Backlog Sub-Tab** (Stories 4.1-4.5) - PARTIALLY COMPLETE
-  - 🔄 Story 4.1 (Display backlog) - PARTIALLY COMPLETE (display done, priority ordering needed)
-  - ⏸️ Story 4.2 (Reorder) - NOT STARTED (blocked by 4.1)
+  - ✅ Story 4.1 (Display backlog) - COMPLETED in PR #267 (merged 2025-10-21)
+  - ✅ Story 4.2 (Reorder) - COMPLETED in PR #267 (merged 2025-10-21)
   - ⏸️ Story 4.3 (Activate) - NOT STARTED
   - ✅ Story 4.4 (Edit) - COMPLETED (via EditProjectModal)
   - ⏸️ Story 4.5 (Filter/search) - DEFERRED
@@ -232,17 +232,19 @@ This phase introduces the Planning tab with three sub-tabs (Project Creation, Pr
 
 #### Tasks
 
-- [ ] Schema: Add `priority` field to `projects.attributes` (number representing rank)
-- [ ] Query: Filter projects by category and `attributes.status = 'backlog'`, order by `attributes.priority`
-- [ ] UI: Stage 4 displays list of existing backlog projects with priority ranks
-- [ ] UI: Show new project card with drag handle for positioning
-- [ ] UI: Operators drag new project into desired position in priority list
-- [ ] UI: Show stage progress indicator (4/4)
-- [ ] UI: "Back to Stage 3", "Save as Low Priority", "Set Priority & Add to Backlog" buttons
-- [ ] Logic: On complete, commit `projectAttributesUpdated` event with `planningStage: 4` and `priority` value
-- [ ] DoD: Operators drag their Stage 4 project into priority order relative to existing projects, with visual positioning and clear completion action.
+- [x] Schema: Add `priority` field to `projects.attributes` for explicit ranking
+- [x] Query/UI: Filter Stage 4 projects (`planningStage = 4`) within the category and order by `attributes.priority` (fallback to append order when unset)
+- [x] UI: Stage 4 backlog sub-tab displays prioritized list with numeric badges and stage indicator
+- [x] UI: Provide drag handles/overlays so operators can reposition projects with DnD Kit
+- [x] Logic: Persist reordered positions by updating `attributes.priority` for all affected projects
+- [x] DoD: Stage 4 projects appear in backlog with a reorderable priority list; newly advanced projects land at the end until repositioned.
 
-**Status**:
+**Status**: ✅ **COMPLETED** in PRs #254, #267 (merged 2025-10-21)
+
+#### Implementation Notes
+
+- Dedicated Stage 4 confirmation buttons from the original concept are deferred; prioritization now happens directly within the backlog tab.
+- Priority is stored on the project record and respected anywhere backlog ordering is required.
 
 ---
 
@@ -254,15 +256,17 @@ This phase introduces the Planning tab with three sub-tabs (Project Creation, Pr
 
 #### Tasks
 
-- [ ] Logic: After completing Stage 4, update `attributes.status = 'backlog'` via `projectAttributesUpdated` event
-- [ ] UI: Show confirmation modal: "Ready to add [Project Name] to your backlog?"
-- [ ] UI: Modal options: "Add to Backlog" (primary), "Keep Planning" (secondary), "Cancel"
-- [ ] UI: On add, commit event updating status to 'backlog'
-- [ ] UI: Project moves from Project Plans to Backlog sub-tab (filtered by status)
-- [ ] UI: Toast notification: "[Project] added to backlog at position #X"
-- [ ] DoD: Completing Stage 4 prompts the operator to move the project to Backlog, which changes its status and relocates it to the Backlog sub-tab.
+- [x] Logic: Clicking "Done Planning" in Stage 3 commits `planningStage: 4` for the project
+- [x] Navigation: Redirect operators to Planning → Backlog sub-tab immediately after advancing
+- [x] UI: Newly advanced project appears in backlog list with Stage 4 badge and inherits reorder controls
+- [x] DoD: Completing Stage 3 moves the project into the backlog-ready queue without manual intervention.
 
-**Status**:
+**Status**: ✅ **COMPLETED** in PR #254 (merged 2025-10-21)
+
+#### Implementation Notes & Follow-ups
+
+- Backlog membership keys off `planningStage = 4`; status remains `'planning'` until activation (Story 4.3 will flip to `'active'`).
+- Original plan called for a confirmation modal and toast—defer until we validate whether the streamlined auto-move needs additional UX affordances.
 
 ---
 
@@ -388,51 +392,29 @@ This phase introduces the Planning tab with three sub-tabs (Project Creation, Pr
 
 #### Tasks
 
-- [ ] Logic: Capture routing context (URL params, pathname) when user sends a message
-- [ ] Logic: Extract `projectId`, `categoryId`, `taskId` from current route dynamically
-- [ ] Query: Fetch current project/category/task details based on extracted IDs
-- [ ] API: Include routing context in each LLM API call as system message or context parameter
-- [ ] API: Format context dynamically based on current view:
-  - Project Workspace: "The user is currently viewing Project '[name]' (ID: [id]) in category '[category]'"
-  - Life Category: "The user is currently viewing the '[category]' Life Category"
-  - Task view: "The user is currently viewing Task '[name]' in Project '[project]'"
-- [ ] Logic: Context is calculated fresh for every message, not stored in conversation
-- [ ] DoD: Every message sent to LLM includes current routing context, enabling contextual references across different views within the same conversation.
+- [x] Capture routing context (URL params, pathname, subtabs) whenever the operator sends a message
+- [x] Extract `projectId`, `categoryId`, `taskId`, etc., and hydrate metadata from LiveStore
+- [x] Attach navigation context to each `chatMessageSent` event and persist it to the database
+- [x] Format navigation-aware system prompt inside the agentic loop for every LLM call
+- [x] DoD: Every message sent to the LLM includes fresh routing context so operators can reference "this project" or "this category" naturally.
 
-**Status**: ⏸️ **NOT STARTED**
+**Status**: ✅ **COMPLETED** in PR #268 (merged 2025-10-21)
 
 #### Implementation Notes
 
-**Dynamic Context Capture:**
+- Introduced `useNavigationContext` hook in the web app to centralize context gathering.
+- `chatMessageSent` event schema and materializer persist `navigationContext` per message.
+- Agentic loop builds a contextual system prompt including current entity + related entities before invoking the provider.
+- Handles Life Category views, project workspace (including subtabs), documents, and contacts; gracefully falls back when no contextual entity exists.
 
-- Read routing state from `useLocation()` and `useParams()` at message send time
-- Parse current URL to extract relevant IDs (projectId, categoryId, taskId)
-- Query LiveStore for entity details (names, descriptions) to enrich context
-- Include context as part of message payload or system prompt for each API call
-
-**Benefits:**
-
-- Same conversation can be used across multiple projects in a category
-- Advisor maintains context awareness as user navigates between views
-- No need to create/switch conversations when moving between projects
-- Natural UX: "help me plan this project" works regardless of which project is open
-
-**Example Implementation:**
+**Example Usage:**
 
 ```typescript
-const handleSendMessage = async (message: string) => {
-  const routingContext = extractRoutingContext(location, params) // { projectId, categoryId, taskId }
-  const contextDetails = await fetchContextDetails(store, routingContext)
-
-  const contextPrompt = formatContextPrompt(contextDetails)
-  // "The user is currently viewing Project 'Morning Workout Routine' in Health & Well-Being category"
-
-  await sendToLLM({
-    message,
-    conversationId,
-    contextPrompt, // Included with this specific message
-  })
-}
+const navigationContext = useNavigationContext()
+await sendMessage({
+  body: draftMessage,
+  navigationContext,
+})
 ```
 
 ---
@@ -445,19 +427,15 @@ const handleSendMessage = async (message: string) => {
 
 #### Tasks
 
-- [ ] Schema: Add `workerCategories` table with columns: `workerId`, `category`
-- [ ] Event: Create `v1.WorkerAssignedToCategory` event with payload `{ workerId, category, assignedAt, actorId }`
-- [ ] Event: Create `v1.WorkerUnassignedFromCategory` event with payload `{ workerId, category }`
-- [ ] Event: Watch for `v1.ProjectCreated` events with `category` field
-- [ ] Logic: On first project creation in a category, check if category advisor worker exists
-- [ ] Logic: If no advisor exists, auto-create worker with `v1.WorkerCreated` event
-- [ ] Logic: After worker creation, commit `v1.WorkerAssignedToCategory` to link worker to category
-- [ ] Schema: Worker naming convention: `{category}-advisor` (e.g., "health-advisor", "finances-advisor")
-- [ ] Prompts: Create category-specific system prompts that understand category context
-- [ ] Prompts: Example for Health category: "You are the Health & Well-Being advisor. Help users plan and manage health-related projects including fitness, medical care, mental health, and nutrition."
-- [ ] DoD: Each Life Category automatically gets a dedicated advisor worker when the first project is created, with proper category assignment tracking.
+- [x] Schema: Added `workerCategories` table to persist advisor assignments
+- [x] Events: Created `v1.WorkerAssignedToCategory` / `v1.WorkerUnassignedFromCategory`
+- [x] Logic: `useCategoryAdvisor` hook auto-creates advisors the first time a category needs one
+- [x] Logic: Automatically links advisors to categories immediately after creation
+- [x] Conventions: `{category}-advisor` IDs with shared name, role, and prompt helpers
+- [x] Prompts: Category-specific system prompts deliver tailored guidance
+- [x] DoD: Each Life Category automatically gains a dedicated advisor with assignment tracking once projects exist.
 
-**Status**: ⏸️ **NOT STARTED**
+**Status**: ✅ **COMPLETED** in PR #266 (merged 2025-10-21)
 
 #### Implementation Notes
 
@@ -475,22 +453,9 @@ const handleSendMessage = async (message: string) => {
 **Implementation Pattern:**
 
 ```typescript
-// Pseudocode for advisor auto-creation
-materializer for 'v1.ProjectCreated': ({ category }) => {
-  if (category) {
-    const advisorId = `${category}-advisor`
-    const existingAdvisor = db.workers.findOne({ id: advisorId })
-
-    if (!existingAdvisor) {
-      store.commit(events.workerCreated({
-        id: advisorId,
-        name: `${getCategoryInfo(category).name} Advisor`,
-        systemPrompt: getCategoryAdvisorPrompt(category),
-        defaultModel: DEFAULT_MODEL,
-        createdAt: new Date(),
-      }))
-    }
-  }
+const { advisorId, isReady } = useCategoryAdvisor(category)
+if (isReady) {
+  // Advisor worker and category assignment now exist for downstream features
 }
 ```
 
@@ -504,16 +469,13 @@ materializer for 'v1.ProjectCreated': ({ category }) => {
 
 #### Tasks
 
-- [ ] Logic: When navigating to Life Category view, check if category advisor exists
-- [ ] Logic: Search for existing conversation with category advisor (by `workerId`)
-- [ ] Logic: If conversation exists, auto-select it (set `conversationId` in URL params)
-- [ ] Logic: If no conversation exists, auto-create conversation with category advisor using `v1.ConversationCreated`
-- [ ] Logic: Conversation title: "[Category Name] Planning" (e.g., "Health & Well-Being Planning")
-- [ ] UI: Chat sidebar auto-selects advisor conversation when entering category view
-- [ ] UI: Show indicator that advisor is context-aware (e.g., "Health Advisor")
-- [ ] DoD: Entering a Life Category view automatically creates or selects a conversation with the category advisor, enabling immediate contextual support.
+- [x] Ensure category advisor exists (Story 3.7) before attempting selection
+- [x] Search for existing advisor conversation by `workerId`; reuse if found
+- [x] Auto-create advisor conversation with standardized title when missing
+- [x] Auto-select advisor conversation by updating `conversationId` URL param on category entry
+- [x] DoD: Navigating to a Life Category ensures the advisor conversation exists and is selected for immediate use.
 
-**Status**: ⏸️ **NOT STARTED**
+**Status**: ✅ **COMPLETED** in PR #266 (merged 2025-10-21)
 
 #### Implementation Notes
 
@@ -524,6 +486,7 @@ materializer for 'v1.ProjectCreated': ({ category }) => {
 - Auto-creation happens once per category (when first navigating to category view after advisor is created)
 - Conversation is reused across all projects in the category
 - User can manually switch to other workers if needed
+- Implemented via `useCategoryAdvisorConversation`, which only sets `conversationId` when the URL does not already specify one.
 
 **UI Behavior:**
 
@@ -588,27 +551,21 @@ materializer for 'v1.ProjectCreated': ({ category }) => {
 - [x] UI: Each card shows: Title, Description preview, Stage indicator
 - [x] UI: Cards numbered with position (#1, #2, #3...)
 - [x] UI: Empty state: "No projects in backlog. Complete Stage 4 planning to add projects here."
-- [ ] Schema: Add `priority` field to `projects.attributes` for explicit ordering
-- [ ] Query: Add ordering by `attributes.priority` when priority field exists
-- [ ] DoD: The Backlog sub-tab shows all completed project plans in priority order with key details visible on each card.
+- [x] Schema: Add `priority` field to `projects.attributes` for explicit ordering
+- [x] Query/UI: Order backlog list by `attributes.priority` with sensible fallback when unset
+- [x] DoD: The Backlog sub-tab shows all completed project plans in priority order with key details visible on each card.
 
-**Status**: 🔄 **PARTIALLY COMPLETE** (basic display implemented in PRs #250, #254; priority ordering NOT implemented)
+**Status**: ✅ **COMPLETED** in PR #267 (merged 2025-10-21)
 
 #### Implementation Notes
 
-**Current Implementation (LifeCategoryPresenter.tsx:162-218):**
+- Projects with `planningStage = 4` are sorted by `attributes.priority` (defaults to list order when undefined) and rendered with numbered badges.
+- Newly advanced projects drop to the end of the list until the operator reorders them (Story 4.2).
+- Empty-state messaging guides operators to complete Stage 4 planning.
 
-- Backlog displays projects with `planningStage = 4`
-- Projects shown in vertical list with numbered positions
-- Basic card layout with title, description, stage badge
-- Empty state message present
-- **Missing**: Priority field in schema, explicit priority ordering, cover images, archetype badges
+**Remaining Enhancements (nice-to-have):**
 
-**What's Needed:**
-
-- Add `priority: number` field to `projects.attributes` schema
-- Implement ordering by priority (lower number = higher priority)
-- Enhance card visuals to show cover, archetype, estimated duration
+- Surface additional metadata (cover thumbnail, archetype badge, estimates) on backlog cards for richer context.
 
 ---
 
@@ -620,18 +577,22 @@ materializer for 'v1.ProjectCreated': ({ category }) => {
 
 #### Tasks
 
-- [ ] Schema: Ensure `priority` field exists in `projects.attributes` (from Story 4.1)
-- [ ] Event: Use `v1.ProjectAttributesUpdated` to update `attributes.priority` field
-- [ ] UI: Enable drag-and-drop on backlog project cards (vertical reordering)
-- [ ] UI: Show blue line indicator at drop position
-- [ ] UI: Other cards shift to show insertion point
-- [ ] Logic: On drop, commit event updating `priority` values for affected projects
-- [ ] Logic: Recalculate priority numbers for all affected projects in sequence
-- [ ] Logic: Priority order persists across sessions
-- [ ] UI: Subtle toast: "[Project] moved to position #X"
-- [ ] DoD: Operators can drag backlog projects to reorder priority, with visual feedback and persistent changes.
+- [x] Leverage `priority` field from Story 4.1 to determine ordering
+- [x] Update `v1.ProjectAttributesUpdated` usage to persist new priority values
+- [x] Enable drag-and-drop reordering with @dnd-kit/sortable
+- [x] Provide insertion indicators / overlays during drag operations
+- [x] Recalculate and commit sequential priorities for all affected projects on drop
+- [x] Persist ordering so refreshes retain operator-defined priorities
+- [x] Show toast notification confirming new position (e.g., "`Project` moved to position #3")
+- [x] DoD: Operators can reorder backlog projects with clear feedback and durable priority changes.
 
-**Status**: ⏸️ **NOT STARTED** (blocked by Story 4.1 priority field)
+**Status**: ✅ **COMPLETED** in PR #267 (merged 2025-10-21)
+
+#### Implementation Notes
+
+- Uses `@dnd-kit/sortable` for vertical list reordering with drag overlays.
+- `isDragInProgress` guard prevents accidental navigation clicks immediately after dropping.
+- Priorities are stored as zero-based integers and recalculated for the entire list on each drop.
 
 ---
 
@@ -643,27 +604,25 @@ materializer for 'v1.ProjectCreated': ({ category }) => {
 
 #### Tasks
 
-- [ ] Schema: Ensure `activatedAt` field exists in `projects.attributes` for tracking activation time
-- [ ] Event: Use `v1.ProjectAttributesUpdated` to update `attributes.status = 'active'` and `attributes.activatedAt`
-- [ ] UI: Add "Activate" button on backlog project cards (consider menu or hover action)
-- [ ] UI: Confirmation modal: "Activate [Project Name]? It will move to your Active projects."
-- [ ] UI: Modal shows: Project title, archetype (if available), task count, estimated duration (if available)
-- [ ] Logic: On confirm, commit event setting `status = 'active'` and `activatedAt = Date.now()`
-- [ ] Logic: Project removed from Backlog sub-tab (filtered by `planningStage`)
-- [ ] Logic: Project appears in Active tab (filtered by `status = 'active'`)
-- [ ] UI: Toast: "[Project] is now active! Start working on tasks."
-- [ ] DoD: Backlog projects can be activated with confirmation, moving them from Backlog to Active tab and enabling task work.
+- [x] Schema: Ensure `activatedAt` field exists in `projects.attributes` for tracking activation time
+- [x] Event/UI: Use `v2.ProjectAttributesUpdated` on activation to set `status = 'active'`, `activatedAt`, and clear backlog-only fields
+- [x] UI: Add "Activate" CTA on backlog project cards
+- [x] UI: Confirmation modal: "Activate [Project Name]? It will move to your Active projects."
+- [x] UI: Modal surfaces project objective, archetype, deadline, and estimated duration when available
+- [x] Logic: On confirm, commit attributes update, show success toast, and navigate to Active tab
+- [x] Logic: Activated project disappears from Backlog (filtered by planning stage) and is visible under Active tab
+- [x] UI: Error toast surfaces if activation fails
+- [x] DoD: Backlog projects can be activated with confirmation, transition to the Active tab, and record activation timing.
 
-**Status**: ⏸️ **NOT STARTED**
+**Status**: ✅ **COMPLETED** (this PR, 2025-10-22)
 
 #### Implementation Notes
 
 **Current Status Check:**
 
-- Projects are already filtered by status in Active tab (LifeCategoryView.tsx:40-44)
-- Active projects filter: `status === 'active' || (!status && !archivedAt && !deletedAt)` (legacy compatibility)
-- Backlog projects filter: `planningStage === 4`
-- **Missing**: Activation UI/UX, status transition logic, activatedAt timestamp
+- Projects in Stage 4 now expose an Activate button with modal confirmation.
+- Activation updates project attributes, records `activatedAt`, and removes backlog-only priority field.
+- Post-activation, the view automatically pivots to the Active tab and shows a success toast.
 
 ---
 

--- a/packages/web/src/components/life-category/LifeCategoryPresenter.tsx
+++ b/packages/web/src/components/life-category/LifeCategoryPresenter.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
+import type { PlanningAttributes } from '@work-squared/shared'
 import type { Project } from '@work-squared/shared/schema'
 import { ProjectCard } from '../projects/ProjectCard/ProjectCard.js'
 import { ProjectCreationView } from '../project-creation/ProjectCreationView.js'
@@ -14,6 +15,7 @@ import {
 } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { ConfirmModal } from '../ui/ConfirmModal/ConfirmModal.js'
 
 export type CategoryTab = 'planning' | 'active' | 'completed'
 export type PlanningSubTab = 'project-creation' | 'project-plans' | 'backlog'
@@ -33,6 +35,7 @@ export interface LifeCategoryPresenterProps {
   onSubTabChange: (subTab: PlanningSubTab) => void
   onProjectClick: (project: Project) => void
   onBacklogReorder?: (event: DragEndEvent) => void
+  onActivateProject?: (project: Project) => Promise<void> | void
 }
 
 // Sortable backlog project card component
@@ -42,6 +45,9 @@ interface SortableBacklogProjectProps {
   categoryColor: string
   onProjectClick: (project: Project) => void
   isDragInProgress: boolean
+  onActivateClick?: (project: Project) => void
+  isActivationInProgress: boolean
+  activationTargetId?: string
 }
 
 const SortableBacklogProject: React.FC<SortableBacklogProjectProps> = ({
@@ -50,6 +56,9 @@ const SortableBacklogProject: React.FC<SortableBacklogProjectProps> = ({
   categoryColor,
   onProjectClick,
   isDragInProgress,
+  onActivateClick,
+  isActivationInProgress,
+  activationTargetId,
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: project.id,
@@ -71,6 +80,16 @@ const SortableBacklogProject: React.FC<SortableBacklogProjectProps> = ({
     onProjectClick(project)
   }
 
+  const handleActivateClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (isActivationInProgress) return
+    onActivateClick?.(project)
+  }
+
+  const isActivatingThisProject =
+    isActivationInProgress && activationTargetId && activationTargetId === project.id
+
   return (
     <div ref={setNodeRef} style={style} {...attributes}>
       <div
@@ -89,7 +108,17 @@ const SortableBacklogProject: React.FC<SortableBacklogProjectProps> = ({
             <p className='text-sm text-gray-500 mt-1'>{project.description}</p>
           )}
         </div>
-        <div className='text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded-md'>Stage 4</div>
+        <div className='flex items-center gap-3'>
+          <div className='text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded-md'>Stage 4</div>
+          <button
+            type='button'
+            onClick={handleActivateClick}
+            disabled={isActivationInProgress}
+            className='px-3 py-1.5 text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-green-500 disabled:opacity-60 disabled:cursor-not-allowed'
+          >
+            {isActivatingThisProject ? 'Activating...' : 'Activate'}
+          </button>
+        </div>
       </div>
     </div>
   )
@@ -109,9 +138,12 @@ export const LifeCategoryPresenter: React.FC<LifeCategoryPresenterProps> = ({
   onSubTabChange,
   onProjectClick,
   onBacklogReorder,
+  onActivateProject,
 }) => {
   const [activeProject, setActiveProject] = useState<Project | null>(null)
   const [isDragInProgress, setIsDragInProgress] = useState(false)
+  const [projectToActivate, setProjectToActivate] = useState<Project | null>(null)
+  const [isConfirmActivating, setIsConfirmActivating] = useState(false)
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -136,6 +168,99 @@ export const LifeCategoryPresenter: React.FC<LifeCategoryPresenterProps> = ({
     // Reset drag state after a brief delay to prevent immediate click
     setTimeout(() => setIsDragInProgress(false), 100)
   }
+
+  const handleActivateClick = (project: Project) => {
+    setProjectToActivate(project)
+  }
+
+  const handleCloseActivateModal = () => {
+    if (isConfirmActivating) return
+    setProjectToActivate(null)
+  }
+
+  const handleConfirmActivate = async () => {
+    if (!projectToActivate || !onActivateProject) return
+    setIsConfirmActivating(true)
+    try {
+      await onActivateProject(projectToActivate)
+      setProjectToActivate(null)
+    } catch (error) {
+      console.error('Failed to activate project', error)
+    } finally {
+      setIsConfirmActivating(false)
+    }
+  }
+
+  const activationDetails = useMemo(() => {
+    if (!projectToActivate) return null
+    const attrs = (projectToActivate.attributes as PlanningAttributes | null) || {}
+
+    const archetype = attrs.archetype ? attrs.archetype : null
+    const estimatedDuration = attrs.estimatedDuration
+    const deadline = attrs.deadline ? new Date(attrs.deadline) : null
+    const objective = attrs.objectives ? String(attrs.objectives) : null
+
+    return {
+      archetype,
+      estimatedDuration,
+      deadline,
+      objective,
+    }
+  }, [projectToActivate])
+
+  const activationMessage = projectToActivate ? (
+    <div className='space-y-3 text-sm'>
+      <p>
+        Activating <span className='font-medium text-gray-900'>{projectToActivate.name}</span> will
+        move it into your Active projects so you can start execution.
+      </p>
+      {activationDetails?.objective ? (
+        <div>
+          <div className='text-xs uppercase font-semibold tracking-wide text-gray-400'>
+            Objective
+          </div>
+          <p className='text-gray-700 mt-1'>{activationDetails.objective}</p>
+        </div>
+      ) : null}
+      <div className='grid grid-cols-1 sm:grid-cols-2 gap-3'>
+        {activationDetails?.archetype ? (
+          <div>
+            <div className='text-xs uppercase font-semibold tracking-wide text-gray-400'>
+              Archetype
+            </div>
+            <p className='text-gray-700 mt-1 capitalize'>{activationDetails.archetype}</p>
+          </div>
+        ) : null}
+        {activationDetails?.deadline ? (
+          <div>
+            <div className='text-xs uppercase font-semibold tracking-wide text-gray-400'>
+              Deadline
+            </div>
+            <p className='text-gray-700 mt-1'>
+              {new Intl.DateTimeFormat(undefined, {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              }).format(activationDetails.deadline)}
+            </p>
+          </div>
+        ) : null}
+        {activationDetails?.estimatedDuration ? (
+          <div>
+            <div className='text-xs uppercase font-semibold tracking-wide text-gray-400'>
+              Est. Duration
+            </div>
+            <p className='text-gray-700 mt-1'>{activationDetails.estimatedDuration} hrs</p>
+          </div>
+        ) : null}
+      </div>
+      <p className='text-gray-600'>
+        You can always adjust tasks and metadata from the project workspace after activation.
+      </p>
+    </div>
+  ) : null
+
+  const activationTargetId = projectToActivate?.id
   const tabs: { id: CategoryTab; label: string }[] = [
     { id: 'planning', label: 'Planning' },
     { id: 'active', label: 'Active' },
@@ -149,235 +274,263 @@ export const LifeCategoryPresenter: React.FC<LifeCategoryPresenterProps> = ({
   ]
 
   return (
-    <div className='h-full bg-white flex flex-col'>
-      {/* Header */}
-      <div className='border-b border-gray-200 bg-white px-6 py-4'>
-        <div className='mb-4'>
-          <h1 className='text-xl font-semibold text-gray-900 mb-1 flex items-center gap-2'>
-            {categoryIcon && <span className='text-2xl'>{categoryIcon}</span>}
-            {categoryName}
-          </h1>
-          <p className='text-gray-600 text-sm'>Manage projects in this life category</p>
-        </div>
+    <>
+      <div className='h-full bg-white flex flex-col'>
+        {/* Header */}
+        <div className='border-b border-gray-200 bg-white px-6 py-4'>
+          <div className='mb-4'>
+            <h1 className='text-xl font-semibold text-gray-900 mb-1 flex items-center gap-2'>
+              {categoryIcon && <span className='text-2xl'>{categoryIcon}</span>}
+              {categoryName}
+            </h1>
+            <p className='text-gray-600 text-sm'>Manage projects in this life category</p>
+          </div>
 
-        {/* Main Tabs */}
-        <div className='flex gap-6 border-b border-gray-200'>
-          {tabs.map(tab => (
-            <button
-              key={tab.id}
-              onClick={() => onTabChange(tab.id)}
-              className={`pb-3 px-1 text-sm font-medium transition-colors relative cursor-pointer ${
-                selectedTab === tab.id
-                  ? 'text-gray-900 border-b-2'
-                  : 'text-gray-500 hover:text-gray-700'
-              }`}
-              style={
-                selectedTab === tab.id
-                  ? {
-                      borderBottomColor: categoryColor,
-                    }
-                  : undefined
-              }
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Planning Sub-tabs (only visible when Planning tab is active) */}
-      {selectedTab === 'planning' && (
-        <div className='border-b border-gray-200 bg-gray-50 px-6'>
-          <div className='flex gap-4 pt-2'>
-            {planningSubTabs.map(subTab => (
+          {/* Main Tabs */}
+          <div className='flex gap-6 border-b border-gray-200'>
+            {tabs.map(tab => (
               <button
-                key={subTab.id}
-                onClick={() => onSubTabChange(subTab.id)}
-                className={`pb-2 px-1 text-xs font-medium transition-colors cursor-pointer ${
-                  selectedSubTab === subTab.id
-                    ? 'text-gray-900 border-b-2 border-gray-900'
+                key={tab.id}
+                onClick={() => onTabChange(tab.id)}
+                className={`pb-3 px-1 text-sm font-medium transition-colors relative cursor-pointer ${
+                  selectedTab === tab.id
+                    ? 'text-gray-900 border-b-2'
                     : 'text-gray-500 hover:text-gray-700'
                 }`}
+                style={
+                  selectedTab === tab.id
+                    ? {
+                        borderBottomColor: categoryColor,
+                      }
+                    : undefined
+                }
               >
-                {subTab.label}
+                {tab.label}
               </button>
             ))}
           </div>
         </div>
-      )}
 
-      {/* Content Area */}
-      <div className='flex-1 overflow-y-auto'>
-        {selectedTab === 'planning' && selectedSubTab === 'project-creation' && (
-          <ProjectCreationView />
-        )}
-
-        {selectedTab === 'planning' && selectedSubTab === 'project-plans' && (
-          <div className='p-6'>
-            {/* Stage Header */}
-            <div className='max-w-2xl mx-auto mb-8'>
-              <div className='flex items-center gap-2 mb-2'>
-                <div
-                  className='w-8 h-8 rounded-full flex items-center justify-center text-white font-semibold'
-                  style={{ backgroundColor: categoryColor }}
+        {/* Planning Sub-tabs (only visible when Planning tab is active) */}
+        {selectedTab === 'planning' && (
+          <div className='border-b border-gray-200 bg-gray-50 px-6'>
+            <div className='flex gap-4 pt-2'>
+              {planningSubTabs.map(subTab => (
+                <button
+                  key={subTab.id}
+                  onClick={() => onSubTabChange(subTab.id)}
+                  className={`pb-2 px-1 text-xs font-medium transition-colors cursor-pointer ${
+                    selectedSubTab === subTab.id
+                      ? 'text-gray-900 border-b-2 border-gray-900'
+                      : 'text-gray-500 hover:text-gray-700'
+                  }`}
                 >
-                  1-3
-                </div>
-                <div>
-                  <h2 className='text-lg font-semibold text-gray-900'>In-Progress Plans</h2>
-                  <p className='text-sm text-gray-500'>Continue planning your projects</p>
-                </div>
-              </div>
-              <div className='flex gap-2 mt-4'>
-                <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
-                <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
-                <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
-                <div className='h-2 flex-1 bg-gray-200 rounded' />
-              </div>
+                  {subTab.label}
+                </button>
+              ))}
             </div>
-
-            {inProgressPlans.length === 0 ? (
-              <div className='text-center py-12'>
-                <h2 className='text-xl font-semibold text-gray-600 mb-2'>
-                  No projects in planning
-                </h2>
-                <p className='text-gray-500'>
-                  Start a new project in Project Creation to begin planning.
-                </p>
-              </div>
-            ) : (
-              <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
-                {inProgressPlans.map(project => (
-                  <ProjectCard
-                    key={project.id}
-                    project={project}
-                    onClick={() => onProjectClick(project)}
-                  />
-                ))}
-              </div>
-            )}
           </div>
         )}
 
-        {selectedTab === 'planning' && selectedSubTab === 'backlog' && (
-          <div className='p-6'>
-            {/* Stage Header */}
-            <div className='max-w-2xl mx-auto mb-8'>
-              <div className='flex items-center gap-2 mb-2'>
-                <div
-                  className='w-8 h-8 rounded-full flex items-center justify-center text-white font-semibold'
-                  style={{ backgroundColor: categoryColor }}
-                >
-                  4
+        {/* Content Area */}
+        <div className='flex-1 overflow-y-auto'>
+          {selectedTab === 'planning' && selectedSubTab === 'project-creation' && (
+            <ProjectCreationView />
+          )}
+
+          {selectedTab === 'planning' && selectedSubTab === 'project-plans' && (
+            <div className='p-6'>
+              {/* Stage Header */}
+              <div className='max-w-2xl mx-auto mb-8'>
+                <div className='flex items-center gap-2 mb-2'>
+                  <div
+                    className='w-8 h-8 rounded-full flex items-center justify-center text-white font-semibold'
+                    style={{ backgroundColor: categoryColor }}
+                  >
+                    1-3
+                  </div>
+                  <div>
+                    <h2 className='text-lg font-semibold text-gray-900'>In-Progress Plans</h2>
+                    <p className='text-sm text-gray-500'>Continue planning your projects</p>
+                  </div>
                 </div>
-                <div>
-                  <h2 className='text-lg font-semibold text-gray-900'>Stage 4: Backlog</h2>
-                  <p className='text-sm text-gray-500'>
-                    Projects ready for prioritization - drag to reorder
+                <div className='flex gap-2 mt-4'>
+                  <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
+                  <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
+                  <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
+                  <div className='h-2 flex-1 bg-gray-200 rounded' />
+                </div>
+              </div>
+
+              {inProgressPlans.length === 0 ? (
+                <div className='text-center py-12'>
+                  <h2 className='text-xl font-semibold text-gray-600 mb-2'>
+                    No projects in planning
+                  </h2>
+                  <p className='text-gray-500'>
+                    Start a new project in Project Creation to begin planning.
                   </p>
                 </div>
-              </div>
-              <div className='flex gap-2 mt-4'>
-                <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
-                <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
-                <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
-                <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
-              </div>
+              ) : (
+                <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
+                  {inProgressPlans.map(project => (
+                    <ProjectCard
+                      key={project.id}
+                      project={project}
+                      onClick={() => onProjectClick(project)}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
+          )}
 
-            {backlogProjects.length === 0 ? (
-              <div className='text-center py-12'>
-                <h2 className='text-xl font-semibold text-gray-600 mb-2'>No projects in backlog</h2>
-                <p className='text-gray-500'>
-                  Complete planning (Stage 4) for a project to add it to the backlog.
-                </p>
-              </div>
-            ) : (
-              <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-                <SortableContext
-                  items={backlogProjects.map(p => p.id)}
-                  strategy={verticalListSortingStrategy}
-                >
-                  <div className='space-y-3'>
-                    {backlogProjects.map((project, index) => (
-                      <SortableBacklogProject
-                        key={project.id}
-                        project={project}
-                        index={index}
-                        categoryColor={categoryColor}
-                        onProjectClick={onProjectClick}
-                        isDragInProgress={isDragInProgress}
-                      />
-                    ))}
+          {selectedTab === 'planning' && selectedSubTab === 'backlog' && (
+            <div className='p-6'>
+              {/* Stage Header */}
+              <div className='max-w-2xl mx-auto mb-8'>
+                <div className='flex items-center gap-2 mb-2'>
+                  <div
+                    className='w-8 h-8 rounded-full flex items-center justify-center text-white font-semibold'
+                    style={{ backgroundColor: categoryColor }}
+                  >
+                    4
                   </div>
-                </SortableContext>
-                <DragOverlay>
-                  {activeProject ? (
-                    <div className='flex items-center gap-4 p-4 bg-white border-2 border-blue-400 rounded-lg shadow-lg'>
-                      <div className='flex-shrink-0 w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center text-sm font-semibold text-gray-600'>
-                        {backlogProjects.findIndex(p => p.id === activeProject.id) + 1}
-                      </div>
-                      <div className='flex-1'>
-                        <h3 className='font-medium text-gray-900'>{activeProject.name}</h3>
-                        {activeProject.description && (
-                          <p className='text-sm text-gray-500 mt-1'>{activeProject.description}</p>
-                        )}
-                      </div>
-                      <div className='text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded-md'>
-                        Stage 4
-                      </div>
+                  <div>
+                    <h2 className='text-lg font-semibold text-gray-900'>Stage 4: Backlog</h2>
+                    <p className='text-sm text-gray-500'>
+                      Projects ready for prioritization - drag to reorder
+                    </p>
+                  </div>
+                </div>
+                <div className='flex gap-2 mt-4'>
+                  <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
+                  <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
+                  <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
+                  <div className='h-2 flex-1 rounded' style={{ backgroundColor: categoryColor }} />
+                </div>
+              </div>
+
+              {backlogProjects.length === 0 ? (
+                <div className='text-center py-12'>
+                  <h2 className='text-xl font-semibold text-gray-600 mb-2'>
+                    No projects in backlog
+                  </h2>
+                  <p className='text-gray-500'>
+                    Complete planning (Stage 4) for a project to add it to the backlog.
+                  </p>
+                </div>
+              ) : (
+                <DndContext
+                  sensors={sensors}
+                  onDragStart={handleDragStart}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={backlogProjects.map(p => p.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <div className='space-y-3'>
+                      {backlogProjects.map((project, index) => (
+                        <SortableBacklogProject
+                          key={project.id}
+                          project={project}
+                          index={index}
+                          categoryColor={categoryColor}
+                          onProjectClick={onProjectClick}
+                          isDragInProgress={isDragInProgress}
+                          onActivateClick={handleActivateClick}
+                          isActivationInProgress={isConfirmActivating}
+                          activationTargetId={activationTargetId}
+                        />
+                      ))}
                     </div>
-                  ) : null}
-                </DragOverlay>
-              </DndContext>
-            )}
-          </div>
-        )}
+                  </SortableContext>
+                  <DragOverlay>
+                    {activeProject ? (
+                      <div className='flex items-center gap-4 p-4 bg-white border-2 border-blue-400 rounded-lg shadow-lg'>
+                        <div className='flex-shrink-0 w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center text-sm font-semibold text-gray-600'>
+                          {backlogProjects.findIndex(p => p.id === activeProject.id) + 1}
+                        </div>
+                        <div className='flex-1'>
+                          <h3 className='font-medium text-gray-900'>{activeProject.name}</h3>
+                          {activeProject.description && (
+                            <p className='text-sm text-gray-500 mt-1'>
+                              {activeProject.description}
+                            </p>
+                          )}
+                        </div>
+                        <div className='text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded-md'>
+                          Stage 4
+                        </div>
+                      </div>
+                    ) : null}
+                  </DragOverlay>
+                </DndContext>
+              )}
+            </div>
+          )}
 
-        {selectedTab === 'active' && (
-          <div className='p-6'>
-            {activeProjects.length === 0 ? (
-              <div className='text-center py-12'>
-                <h2 className='text-xl font-semibold text-gray-600 mb-2'>No active projects</h2>
-                <p className='text-gray-500'>Create projects in the Planning tab to get started.</p>
-              </div>
-            ) : (
-              <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
-                {activeProjects.map(project => (
-                  <ProjectCard
-                    key={project.id}
-                    project={project}
-                    onClick={() => onProjectClick(project)}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        )}
+          {selectedTab === 'active' && (
+            <div className='p-6'>
+              {activeProjects.length === 0 ? (
+                <div className='text-center py-12'>
+                  <h2 className='text-xl font-semibold text-gray-600 mb-2'>No active projects</h2>
+                  <p className='text-gray-500'>
+                    Create projects in the Planning tab to get started.
+                  </p>
+                </div>
+              ) : (
+                <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
+                  {activeProjects.map(project => (
+                    <ProjectCard
+                      key={project.id}
+                      project={project}
+                      onClick={() => onProjectClick(project)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
-        {selectedTab === 'completed' && (
-          <div className='p-6'>
-            {completedProjects.length === 0 ? (
-              <div className='text-center py-12'>
-                <h2 className='text-xl font-semibold text-gray-600 mb-2'>No completed projects</h2>
-                <p className='text-gray-500'>
-                  Completed projects will appear here when you finish them.
-                </p>
-              </div>
-            ) : (
-              <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
-                {completedProjects.map(project => (
-                  <ProjectCard
-                    key={project.id}
-                    project={project}
-                    onClick={() => onProjectClick(project)}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        )}
+          {selectedTab === 'completed' && (
+            <div className='p-6'>
+              {completedProjects.length === 0 ? (
+                <div className='text-center py-12'>
+                  <h2 className='text-xl font-semibold text-gray-600 mb-2'>
+                    No completed projects
+                  </h2>
+                  <p className='text-gray-500'>
+                    Completed projects will appear here when you finish them.
+                  </p>
+                </div>
+              ) : (
+                <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
+                  {completedProjects.map(project => (
+                    <ProjectCard
+                      key={project.id}
+                      project={project}
+                      onClick={() => onProjectClick(project)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+
+      <ConfirmModal
+        isOpen={!!projectToActivate}
+        onClose={handleCloseActivateModal}
+        onConfirm={handleConfirmActivate}
+        title={projectToActivate ? `Activate ${projectToActivate.name}?` : 'Activate project'}
+        message={activationMessage}
+        confirmText='Activate Project'
+        cancelText='Not Yet'
+        isLoading={isConfirmActivating}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add activation CTA to backlog cards with confirmation modal
- persist project activation status/timestamps, clear backlog priority, and shift the view to Active
- surface planning metadata during activation and toast success/error for operators

## Testing
- pnpm lint-all
- pnpm test
- CI=true pnpm test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an Activate action with confirmation for backlog projects, persists activation state, hardens advisor creation, and updates Phase 2 docs/progress.
> 
> - **Frontend (Life Category)**:
>   - **Activation**: Add `Activate` CTA to backlog cards with confirmation modal in `LifeCategoryPresenter.tsx` and handler in `LifeCategoryView.tsx`.
>     - Persists `status = 'active'`, `activatedAt`, `lastActivityAt`, clears backlog-only fields, shows toasts, and navigates to `Active` tab.
>     - Surfaces planning metadata (objective, archetype, deadline, est. duration) in modal.
>   - **Backlog UI**: Enhances sortable backlog item with activation state/disabled handling and drag overlays.
> - **Hooks**:
>   - `useCategoryAdvisor`: Adds concurrency guard (`pendingAdvisorCreation`) and unique-constraint handling to avoid duplicate advisor creation; ensures category assignment.
> - **Docs**:
>   - Update Phase 2 status in `docs/plans/023-life-squared-epic/*`:
>     - Mark backlog display/reorder and activation complete; add routing-context messaging and category advisor auto-create/auto-select as completed; expand completed PR list and story counts; refine outstanding items and implementation notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9557a8011d85177caae584568260db32cf0f41d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->