### PR TITLE
Add workspace orchestrator core

### DIFF
--- a/packages/server/src/services/workspace-orchestrator.ts
+++ b/packages/server/src/services/workspace-orchestrator.ts
@@ -1,0 +1,166 @@
+import { operationLogger, storeLogger } from '../utils/logger.js'
+import type { StoreManager } from './store-manager.js'
+import type { EventProcessor } from './event-processor.js'
+import type { Store as LiveStore } from '@livestore/livestore'
+
+interface MonitoredStoreMetadata {
+  storeId: string
+  firstMonitoredAt: Date
+  lastEnsuredAt: Date
+  lastStoppedAt?: Date
+  status: 'monitoring' | 'stopped'
+}
+
+export interface WorkspaceOrchestratorSummary {
+  monitoredStoreIds: string[]
+  lastProvisionedAt: string | null
+  lastDeprovisionedAt: string | null
+  totalProvisioned: number
+  totalDeprovisioned: number
+  stores: Array<{
+    storeId: string
+    status: 'monitoring' | 'stopped'
+    firstMonitoredAt: string
+    lastEnsuredAt: string
+    lastStoppedAt: string | null
+  }>
+}
+
+export class WorkspaceOrchestrator {
+  private readonly storeManager: StoreManager
+  private readonly eventProcessor: EventProcessor
+  private readonly storeMetadata = new Map<string, MonitoredStoreMetadata>()
+  private lastProvisionedAt: Date | null = null
+  private lastDeprovisionedAt: Date | null = null
+  private totalProvisioned = 0
+  private totalDeprovisioned = 0
+
+  constructor(storeManager: StoreManager, eventProcessor: EventProcessor) {
+    this.storeManager = storeManager
+    this.eventProcessor = eventProcessor
+  }
+
+  async ensureMonitored(storeId: string): Promise<void> {
+    const log = operationLogger('workspace_orchestrator.ensure_monitored', { storeId })
+
+    const existingMetadata = this.storeMetadata.get(storeId)
+    const alreadyMonitoring = existingMetadata?.status === 'monitoring'
+
+    try {
+      const store = await this.resolveStore(storeId)
+
+      await this.eventProcessor.startMonitoring(storeId, store)
+
+      const now = new Date()
+      if (!alreadyMonitoring) {
+        this.totalProvisioned += 1
+        this.lastProvisionedAt = now
+      }
+
+      const metadata: MonitoredStoreMetadata = existingMetadata
+        ? {
+            ...existingMetadata,
+            lastEnsuredAt: now,
+            status: 'monitoring',
+          }
+        : {
+            storeId,
+            firstMonitoredAt: now,
+            lastEnsuredAt: now,
+            status: 'monitoring',
+          }
+
+      metadata.lastStoppedAt = existingMetadata?.lastStoppedAt
+      this.storeMetadata.set(storeId, metadata)
+
+      log.info({ status: alreadyMonitoring ? 'already_monitoring' : 'monitoring_started' })
+    } catch (error) {
+      log.error({ error }, 'Failed to ensure store is monitored')
+      throw error
+    }
+  }
+
+  async stopMonitoring(storeId: string): Promise<void> {
+    const log = operationLogger('workspace_orchestrator.stop_monitoring', { storeId })
+
+    const metadata = this.storeMetadata.get(storeId)
+    const wasMonitoring = metadata?.status === 'monitoring'
+
+    try {
+      this.eventProcessor.stopMonitoring(storeId)
+      await this.storeManager.removeStore(storeId)
+
+      const now = new Date()
+
+      if (wasMonitoring) {
+        this.totalDeprovisioned += 1
+        this.lastDeprovisionedAt = now
+      }
+
+      this.storeMetadata.set(storeId, {
+        storeId,
+        firstMonitoredAt: metadata?.firstMonitoredAt ?? now,
+        lastEnsuredAt: metadata?.lastEnsuredAt ?? now,
+        lastStoppedAt: now,
+        status: 'stopped',
+      })
+
+      log.info({ status: wasMonitoring ? 'monitoring_stopped' : 'already_stopped' })
+    } catch (error) {
+      log.error({ error }, 'Failed to stop monitoring store')
+      throw error
+    }
+  }
+
+  listMonitored(): string[] {
+    return Array.from(this.storeMetadata.values())
+      .filter(metadata => metadata.status === 'monitoring')
+      .map(metadata => metadata.storeId)
+      .sort()
+  }
+
+  getSummary(): WorkspaceOrchestratorSummary {
+    return {
+      monitoredStoreIds: this.listMonitored(),
+      lastProvisionedAt: this.lastProvisionedAt?.toISOString() ?? null,
+      lastDeprovisionedAt: this.lastDeprovisionedAt?.toISOString() ?? null,
+      totalProvisioned: this.totalProvisioned,
+      totalDeprovisioned: this.totalDeprovisioned,
+      stores: Array.from(this.storeMetadata.values()).map(metadata => ({
+        storeId: metadata.storeId,
+        status: metadata.status,
+        firstMonitoredAt: metadata.firstMonitoredAt.toISOString(),
+        lastEnsuredAt: metadata.lastEnsuredAt.toISOString(),
+        lastStoppedAt: metadata.lastStoppedAt?.toISOString() ?? null,
+      })),
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    const log = operationLogger('workspace_orchestrator.shutdown')
+    log.info('Shutting down workspace orchestrator')
+
+    const monitoredStores = this.listMonitored()
+    for (const storeId of monitoredStores) {
+      try {
+        await this.stopMonitoring(storeId)
+      } catch (error) {
+        storeLogger(storeId).error({ error }, 'Failed to stop monitoring during shutdown')
+      }
+    }
+
+    this.eventProcessor.stopAll()
+    await this.storeManager.shutdown()
+    log.info('Workspace orchestrator shutdown complete')
+  }
+
+  private async resolveStore(storeId: string): Promise<LiveStore> {
+    const existing = this.storeManager.getStore(storeId)
+    if (existing) {
+      storeLogger(storeId).debug('Store already exists, reusing instance')
+      return existing
+    }
+
+    return await this.storeManager.addStore(storeId)
+  }
+}

--- a/packages/server/tests/services/workspace-orchestrator.test.ts
+++ b/packages/server/tests/services/workspace-orchestrator.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Store as LiveStore } from '@livestore/livestore'
+import { WorkspaceOrchestrator } from '../../src/services/workspace-orchestrator.js'
+import type { StoreManager } from '../../src/services/store-manager.js'
+import type { EventProcessor } from '../../src/services/event-processor.js'
+
+const createLiveStore = (): LiveStore =>
+  ({
+    shutdownPromise: vi.fn().mockResolvedValue(undefined),
+  }) as unknown as LiveStore
+
+describe('WorkspaceOrchestrator', () => {
+  let mockStoreManager: StoreManager
+  let mockEventProcessor: EventProcessor
+  let orchestrator: WorkspaceOrchestrator
+  let liveStore: LiveStore
+  let getStoreMock: ReturnType<typeof vi.fn>
+  let addStoreMock: ReturnType<typeof vi.fn>
+  let removeStoreMock: ReturnType<typeof vi.fn>
+  let shutdownMock: ReturnType<typeof vi.fn>
+  let startMonitoringMock: ReturnType<typeof vi.fn>
+  let stopMonitoringMock: ReturnType<typeof vi.fn>
+  let stopAllMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    liveStore = createLiveStore()
+
+    getStoreMock = vi.fn().mockReturnValue(liveStore)
+    addStoreMock = vi.fn().mockResolvedValue(liveStore)
+    removeStoreMock = vi.fn().mockResolvedValue(undefined)
+    shutdownMock = vi.fn().mockResolvedValue(undefined)
+
+    mockStoreManager = {
+      getStore: getStoreMock,
+      addStore: addStoreMock,
+      removeStore: removeStoreMock,
+      shutdown: shutdownMock,
+    } as unknown as StoreManager
+
+    startMonitoringMock = vi.fn().mockResolvedValue(undefined)
+    stopMonitoringMock = vi.fn()
+    stopAllMock = vi.fn()
+
+    mockEventProcessor = {
+      startMonitoring: startMonitoringMock,
+      stopMonitoring: stopMonitoringMock,
+      stopAll: stopAllMock,
+    } as unknown as EventProcessor
+
+    orchestrator = new WorkspaceOrchestrator(mockStoreManager, mockEventProcessor)
+  })
+
+  it('ensures monitoring for existing stores idempotently', async () => {
+    const storeId = 'store-123'
+
+    await orchestrator.ensureMonitored(storeId)
+    await orchestrator.ensureMonitored(storeId)
+
+    expect(getStoreMock).toHaveBeenCalledWith(storeId)
+    expect(addStoreMock).not.toHaveBeenCalled()
+    expect(startMonitoringMock).toHaveBeenCalledTimes(2)
+
+    const summary = orchestrator.getSummary()
+    expect(summary.monitoredStoreIds).toEqual([storeId])
+    expect(summary.totalProvisioned).toBe(1)
+  })
+
+  it('adds stores that are not already managed before monitoring', async () => {
+    const storeId = 'store-new'
+    getStoreMock.mockReturnValueOnce(null)
+
+    await orchestrator.ensureMonitored(storeId)
+
+    expect(addStoreMock).toHaveBeenCalledWith(storeId)
+    expect(startMonitoringMock).toHaveBeenCalledWith(storeId, liveStore)
+  })
+
+  it('stops monitoring and updates summary metadata', async () => {
+    const storeId = 'store-stop'
+
+    await orchestrator.ensureMonitored(storeId)
+    await orchestrator.stopMonitoring(storeId)
+
+    expect(stopMonitoringMock).toHaveBeenCalledWith(storeId)
+    expect(removeStoreMock).toHaveBeenCalledWith(storeId)
+
+    const summary = orchestrator.getSummary()
+    expect(summary.monitoredStoreIds).toEqual([])
+    expect(summary.totalDeprovisioned).toBe(1)
+    const storeEntry = summary.stores.find(entry => entry.storeId === storeId)
+    expect(storeEntry?.status).toBe('stopped')
+    expect(storeEntry?.lastStoppedAt).not.toBeNull()
+  })
+
+  it('shutdown stops monitored stores and delegates to dependencies', async () => {
+    const firstStore = 'store-a'
+    const secondStore = 'store-b'
+
+    await orchestrator.ensureMonitored(firstStore)
+    await orchestrator.ensureMonitored(secondStore)
+
+    await orchestrator.shutdown()
+
+    expect(stopMonitoringMock).toHaveBeenCalledWith(firstStore)
+    expect(stopMonitoringMock).toHaveBeenCalledWith(secondStore)
+    expect(stopAllMock).toHaveBeenCalledTimes(1)
+    expect(shutdownMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add WorkspaceOrchestrator to orchestrate store manager and event processor, tracking provisioning metadata
- refactor server bootstrap/shutdown and health endpoints to use orchestrator summary and support legacy store bootstrapping
- add targeted unit tests covering orchestrator idempotency, provisioning, and shutdown behavior

## Testing
- pnpm lint-all
- pnpm test
- CI=true pnpm test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `WorkspaceOrchestrator` to manage store monitoring, integrates it into server startup/health APIs and shutdown, and adds focused unit tests.
> 
> - **Server**:
>   - **Orchestration**: Add `WorkspaceOrchestrator` (`packages/server/src/services/workspace-orchestrator.ts`) to provision/deprovision stores, track monitoring metadata, and summarize status.
>   - **Bootstrap**: Update `packages/server/src/index.ts` to instantiate orchestrator, ensure configured stores are monitored, and use orchestrator for graceful shutdown.
>   - **Health/Stores APIs**:
>     - `/health`: Include `orchestrator` summary alongside processing and live store stats.
>     - `/stores`: Add per-store orchestrator info and a top-level orchestrator summary (monitored IDs, last provision/deprovision timestamps, totals).
> - **Tests**:
>   - Add `packages/server/tests/services/workspace-orchestrator.test.ts` covering idempotent monitoring, provisioning of new stores, stopping, and shutdown delegation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b5605df3426714a34cf941463ed7e9e79f1532a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->