### PR TITLE
Add workspace webhook ingestion

### DIFF
--- a/packages/auth-worker/src/handlers/auth.ts
+++ b/packages/auth-worker/src/handlers/auth.ts
@@ -272,6 +272,8 @@ interface Env {
   USER_STORE: any
   BOOTSTRAP_ADMIN_EMAIL?: string
   DISCORD_WEBHOOK_URL?: string
+  SERVER_WEBHOOK_URL?: string
+  WEBHOOK_SECRET?: string
 }
 
 interface DurableObjectStub {

--- a/packages/auth-worker/src/test/workspace-notifier.test.ts
+++ b/packages/auth-worker/src/test/workspace-notifier.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  notifyWorkspaceEvent,
+  type WorkspaceEventPayload,
+  type WorkspaceEnv,
+} from '../workspace-notifier.js'
+
+const basePayload: WorkspaceEventPayload = {
+  event: 'workspace.created',
+  instanceId: 'workspace-123',
+  userId: 'user-456',
+  timestamp: new Date().toISOString(),
+}
+
+describe('notifyWorkspaceEvent', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('skips notification when SERVER_WEBHOOK_URL is not configured', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response)
+    const env: WorkspaceEnv = { SERVER_WEBHOOK_URL: '', WEBHOOK_SECRET: 'secret' }
+
+    await notifyWorkspaceEvent(env, basePayload)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('skips notification when WEBHOOK_SECRET is not configured', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response)
+    const env: WorkspaceEnv = {
+      SERVER_WEBHOOK_URL: 'https://example.com/webhook',
+      WEBHOOK_SECRET: '',
+    }
+
+    await notifyWorkspaceEvent(env, basePayload)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('sends webhook when configuration is present', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response)
+    const env: WorkspaceEnv = {
+      SERVER_WEBHOOK_URL: 'https://example.com/webhook',
+      WEBHOOK_SECRET: 'secret',
+    }
+
+    await notifyWorkspaceEvent(env, basePayload)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      env.SERVER_WEBHOOK_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-Webhook-Secret': env.WEBHOOK_SECRET }),
+      })
+    )
+  })
+
+  it('retries on failure and eventually succeeds', async () => {
+    const responses = [
+      { ok: false, status: 500 } as Response,
+      { ok: false, status: 500 } as Response,
+      { ok: true } as Response,
+    ]
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => Promise.resolve(responses.shift()!))
+
+    const env: WorkspaceEnv = {
+      SERVER_WEBHOOK_URL: 'https://example.com/webhook',
+      WEBHOOK_SECRET: 'secret',
+    }
+
+    const promise = notifyWorkspaceEvent(env, basePayload)
+
+    await vi.runAllTimersAsync()
+    await promise
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/auth-worker/src/utils/adminAuth.ts
+++ b/packages/auth-worker/src/utils/adminAuth.ts
@@ -43,4 +43,7 @@ interface Env {
   JWT_SECRET?: string
   USER_STORE: any
   BOOTSTRAP_ADMIN_EMAIL?: string
+  DISCORD_WEBHOOK_URL?: string
+  SERVER_WEBHOOK_URL?: string
+  WEBHOOK_SECRET?: string
 }

--- a/packages/auth-worker/src/utils/jwt.ts
+++ b/packages/auth-worker/src/utils/jwt.ts
@@ -195,4 +195,7 @@ interface Env {
   JWT_SECRET?: string
   USER_STORE: any
   BOOTSTRAP_ADMIN_EMAIL?: string
+  DISCORD_WEBHOOK_URL?: string
+  SERVER_WEBHOOK_URL?: string
+  WEBHOOK_SECRET?: string
 }

--- a/packages/auth-worker/src/workspace-notifier.ts
+++ b/packages/auth-worker/src/workspace-notifier.ts
@@ -1,0 +1,94 @@
+const MAX_ATTEMPTS = 3
+const BASE_DELAY_MS = 500
+
+export type WorkspaceEnv = {
+  SERVER_WEBHOOK_URL?: string
+  WEBHOOK_SECRET?: string
+}
+
+type WorkspaceEventType = 'workspace.created' | 'workspace.deleted'
+
+export interface WorkspaceEventPayload {
+  event: WorkspaceEventType
+  instanceId: string
+  userId: string
+  timestamp: string
+}
+
+const WEBHOOK_SECRET_HEADER = 'X-Webhook-Secret'
+const CLIENT_HEADER = 'X-Client-Name'
+
+export async function notifyWorkspaceEvent(
+  env: WorkspaceEnv,
+  payload: WorkspaceEventPayload
+): Promise<void> {
+  const url = env.SERVER_WEBHOOK_URL?.trim()
+  if (!url) {
+    console.debug('Workspace webhook skipped: SERVER_WEBHOOK_URL not configured', payload.event)
+    return
+  }
+
+  const secret = env.WEBHOOK_SECRET?.trim()
+  if (!secret) {
+    console.warn('Workspace webhook skipped: WEBHOOK_SECRET not configured', payload.event)
+    return
+  }
+
+  let attempt = 0
+  while (attempt < MAX_ATTEMPTS) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [WEBHOOK_SECRET_HEADER]: secret,
+          [CLIENT_HEADER]: 'work-squared-auth-worker',
+        },
+        body: JSON.stringify(payload),
+      })
+
+      if (response.ok) {
+        if (attempt > 0) {
+          console.info('Workspace webhook delivered after retry', {
+            event: payload.event,
+            attempt: attempt + 1,
+          })
+        }
+        return
+      }
+
+      const body = await safeReadBody(response)
+      console.warn('Workspace webhook failed', {
+        event: payload.event,
+        status: response.status,
+        attempt: attempt + 1,
+        body,
+      })
+    } catch (error) {
+      console.error('Workspace webhook error', {
+        event: payload.event,
+        attempt: attempt + 1,
+        error,
+      })
+    }
+
+    attempt++
+    if (attempt < MAX_ATTEMPTS) {
+      await delay(BASE_DELAY_MS * Math.pow(2, attempt - 1))
+    }
+  }
+}
+
+async function safeReadBody(response: Response): Promise<string | undefined> {
+  try {
+    const clone = response.clone()
+    const text = await clone.text()
+    return text.slice(0, 512)
+  } catch {
+    return undefined
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/packages/auth-worker/wrangler.toml
+++ b/packages/auth-worker/wrangler.toml
@@ -4,6 +4,8 @@ main = "./src/index.ts"
 
 [vars]
 ENVIRONMENT = "development"
+SERVER_WEBHOOK_URL = ""
+WEBHOOK_SECRET = ""
 
 [[durable_objects.bindings]]
 name = "USER_STORE"

--- a/packages/server/src/api/workspace-webhooks.ts
+++ b/packages/server/src/api/workspace-webhooks.ts
@@ -1,0 +1,140 @@
+import type { IncomingMessage, ServerResponse } from 'http'
+import { operationLogger } from '../utils/logger.js'
+import type { WorkspaceOrchestrator } from '../services/workspace-orchestrator.js'
+
+const logger = operationLogger('workspace_webhook')
+
+export interface WorkspaceWebhookOptions {
+  orchestrator: WorkspaceOrchestrator
+  secret?: string
+}
+
+interface WorkspaceWebhookPayload {
+  event: 'workspace.created' | 'workspace.deleted'
+  instanceId: string
+  userId: string
+  timestamp: string
+}
+
+export async function handleWorkspaceWebhook(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: WorkspaceWebhookOptions
+): Promise<void> {
+  if (req.method !== 'POST') {
+    respond(res, 405, { error: 'Method not allowed' })
+    return
+  }
+
+  if (!options.secret) {
+    logger.error('Workspace webhook secret is not configured')
+    respond(res, 500, { error: 'Webhook secret not configured' })
+    return
+  }
+
+  const providedSecret = extractSecret(req)
+  if (providedSecret !== options.secret) {
+    logger.warn('Workspace webhook secret mismatch')
+    respond(res, 401, { error: 'Unauthorized' })
+    return
+  }
+
+  let payload: WorkspaceWebhookPayload
+  try {
+    payload = await parsePayload(req)
+  } catch (error) {
+    logger.warn({ error }, 'Failed to parse workspace webhook payload')
+    respond(res, 400, { error: 'Invalid JSON payload' })
+    return
+  }
+
+  const validationError = validatePayload(payload)
+  if (validationError) {
+    logger.warn({ validationError }, 'Workspace webhook payload validation failed')
+    respond(res, 400, { error: validationError })
+    return
+  }
+
+  const receivedAt = new Date().toISOString()
+  const { orchestrator } = options
+  const wasMonitoring = orchestrator.listMonitored().includes(payload.instanceId)
+
+  try {
+    let status: string
+    if (payload.event === 'workspace.created') {
+      await orchestrator.ensureMonitored(payload.instanceId)
+      const isMonitoring = orchestrator.listMonitored().includes(payload.instanceId)
+      status = isMonitoring && !wasMonitoring ? 'monitoring_started' : 'already_monitored'
+    } else {
+      await orchestrator.stopMonitoring(payload.instanceId)
+      const isMonitoring = orchestrator.listMonitored().includes(payload.instanceId)
+      status = wasMonitoring && !isMonitoring ? 'monitoring_stopped' : 'already_stopped'
+    }
+
+    logger.info(
+      { event: payload.event, status, instanceId: payload.instanceId },
+      'Workspace webhook processed'
+    )
+    respond(res, 200, { status, receivedAt })
+  } catch (error) {
+    logger.error({ error, event: payload.event }, 'Workspace webhook handling failed')
+    respond(res, 500, { error: 'Internal server error' })
+  }
+}
+
+function extractSecret(req: IncomingMessage): string | undefined {
+  const header = req.headers['x-webhook-secret']
+  if (Array.isArray(header)) {
+    return header[0]
+  }
+  return header ?? undefined
+}
+
+async function parsePayload(req: IncomingMessage): Promise<WorkspaceWebhookPayload> {
+  const body = await readRequestBody(req)
+  return JSON.parse(body)
+}
+
+function validatePayload(payload: WorkspaceWebhookPayload): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return 'Payload must be an object'
+  }
+
+  if (!payload.event || !['workspace.created', 'workspace.deleted'].includes(payload.event)) {
+    return 'Unsupported event type'
+  }
+
+  if (!payload.instanceId || typeof payload.instanceId !== 'string') {
+    return 'instanceId is required'
+  }
+
+  if (!payload.userId || typeof payload.userId !== 'string') {
+    return 'userId is required'
+  }
+
+  if (!payload.timestamp || typeof payload.timestamp !== 'string') {
+    return 'timestamp is required'
+  }
+
+  return null
+}
+
+function respond(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+
+  return await new Promise<string>((resolve, reject) => {
+    req
+      .on('data', chunk => {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+      })
+      .on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf8'))
+      })
+      .on('error', reject)
+  })
+}

--- a/packages/server/tests/api/workspace-webhooks.test.ts
+++ b/packages/server/tests/api/workspace-webhooks.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PassThrough } from 'stream'
+import type { IncomingMessage, ServerResponse } from 'http'
+import { handleWorkspaceWebhook } from '../../src/api/workspace-webhooks.js'
+import type { WorkspaceWebhookOptions } from '../../src/api/workspace-webhooks.js'
+
+class MockResponse {
+  status?: number
+  headers: Record<string, string> = {}
+  body?: string
+
+  writeHead(status: number, headers: Record<string, string>) {
+    this.status = status
+    this.headers = headers
+    return this
+  }
+
+  end(body?: string) {
+    this.body = body
+  }
+
+  setHeader() {}
+}
+
+class FakeOrchestrator {
+  private monitored = new Set<string>()
+  ensureMonitored = vi.fn(async (storeId: string) => {
+    this.monitored.add(storeId)
+  })
+  stopMonitoring = vi.fn(async (storeId: string) => {
+    this.monitored.delete(storeId)
+  })
+  listMonitored = vi.fn(() => Array.from(this.monitored).sort())
+}
+
+function createRequest(
+  payload: unknown,
+  headers: Record<string, string> = {}
+): IncomingMessage & { method: string; headers: Record<string, string> } {
+  const stream = new PassThrough() as IncomingMessage & {
+    method: string
+    headers: Record<string, string>
+  }
+  stream.method = 'POST'
+  stream.headers = { 'content-type': 'application/json', ...headers }
+  if (typeof payload === 'string') {
+    stream.end(payload)
+  } else {
+    stream.end(JSON.stringify(payload))
+  }
+  return stream
+}
+
+function createOptions(orchestrator: FakeOrchestrator, secret?: string): WorkspaceWebhookOptions {
+  return {
+    orchestrator: orchestrator as unknown as WorkspaceWebhookOptions['orchestrator'],
+    secret,
+  }
+}
+
+describe('handleWorkspaceWebhook', () => {
+  const secret = 'super-secret'
+  const basePayload = {
+    event: 'workspace.created' as const,
+    instanceId: 'workspace-123',
+    userId: 'user-abc',
+    timestamp: new Date().toISOString(),
+  }
+
+  let orchestrator: FakeOrchestrator
+
+  beforeEach(() => {
+    orchestrator = new FakeOrchestrator()
+  })
+
+  it('returns 401 when webhook secret does not match', async () => {
+    const req = createRequest(basePayload, { 'x-webhook-secret': 'wrong' })
+    const res = new MockResponse()
+
+    await handleWorkspaceWebhook(req, res as unknown as ServerResponse, createOptions(orchestrator, secret))
+
+    expect(res.status).toBe(401)
+    expect(JSON.parse(res.body ?? '{}').error).toBe('Unauthorized')
+    expect(orchestrator.ensureMonitored).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when payload is invalid JSON', async () => {
+    const req = createRequest('{invalid-json', { 'x-webhook-secret': secret })
+    const res = new MockResponse()
+
+    await handleWorkspaceWebhook(req, res as unknown as ServerResponse, createOptions(orchestrator, secret))
+
+    expect(res.status).toBe(400)
+    expect(JSON.parse(res.body ?? '{}').error).toBe('Invalid JSON payload')
+  })
+
+  it('starts monitoring a workspace on creation events', async () => {
+    const req = createRequest(basePayload, { 'x-webhook-secret': secret })
+    const res = new MockResponse()
+
+    await handleWorkspaceWebhook(req, res as unknown as ServerResponse, createOptions(orchestrator, secret))
+
+    expect(orchestrator.ensureMonitored).toHaveBeenCalledWith(basePayload.instanceId)
+    expect(res.status).toBe(200)
+    const body = JSON.parse(res.body ?? '{}')
+    expect(body.status).toBe('monitoring_started')
+  })
+
+  it('reports already monitored when workspace is already tracked', async () => {
+    await orchestrator.ensureMonitored(basePayload.instanceId)
+
+    const req = createRequest(basePayload, { 'x-webhook-secret': secret })
+    const res = new MockResponse()
+
+    await handleWorkspaceWebhook(req, res as unknown as ServerResponse, createOptions(orchestrator, secret))
+
+    expect(res.status).toBe(200)
+    const body = JSON.parse(res.body ?? '{}')
+    expect(body.status).toBe('already_monitored')
+    expect(orchestrator.ensureMonitored).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops monitoring on deletion events', async () => {
+    await orchestrator.ensureMonitored(basePayload.instanceId)
+
+    const deletePayload = { ...basePayload, event: 'workspace.deleted' as const }
+    const req = createRequest(deletePayload, { 'x-webhook-secret': secret })
+    const res = new MockResponse()
+
+    await handleWorkspaceWebhook(req, res as unknown as ServerResponse, createOptions(orchestrator, secret))
+
+    expect(orchestrator.stopMonitoring).toHaveBeenCalledWith(basePayload.instanceId)
+    expect(res.status).toBe(200)
+    const body = JSON.parse(res.body ?? '{}')
+    expect(body.status).toBe('monitoring_stopped')
+  })
+
+  it('handles repeated deletion idempotently', async () => {
+    const deletePayload = { ...basePayload, event: 'workspace.deleted' as const }
+    const req = createRequest(deletePayload, { 'x-webhook-secret': secret })
+    const res = new MockResponse()
+
+    await handleWorkspaceWebhook(req, res as unknown as ServerResponse, createOptions(orchestrator, secret))
+
+    expect(orchestrator.stopMonitoring).toHaveBeenCalledWith(basePayload.instanceId)
+    expect(res.status).toBe(200)
+    const body = JSON.parse(res.body ?? '{}')
+    expect(body.status).toBe('already_stopped')
+  })
+})


### PR DESCRIPTION
## Summary
- notify the multi-store server when workspaces are created or deleted from the auth worker
- add optional webhook notifier with retries and secure headers in the auth worker
- expose a workspace webhook endpoint on the server that authenticates requests and updates the orchestrator
- cover the notifier and webhook handler with targeted unit tests

## Testing
- pnpm lint-all
- pnpm test
- CI=true pnpm test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auth worker now emits signed workspace create/delete webhooks with retries, and the server exposes a verified endpoint to start/stop orchestrator monitoring.
> 
> - **Auth Worker**
>   - **Workspace webhooks**: Add `notifyWorkspaceEvent` with exponential backoff, `X-Webhook-Secret`, and custom UA; called on `workspace.created` and `workspace.deleted` after successful DO ops via `ctx.waitUntil`.
>   - **Execution/context**: Update worker `fetch` to accept `ctx`; introduce `WorkerExecutionContext`.
>   - **Config**: Add `SERVER_WEBHOOK_URL` and `WEBHOOK_SECRET` to `Env` and `wrangler.toml`.
> - **Server**
>   - **New endpoint**: `POST /webhooks/workspaces` validates `X-Webhook-Secret`, parses/validates payload, and `ensureMonitored`/`stopMonitoring` via `WorkspaceOrchestrator`; add routing and CORS header allowances.
> - **Tests**
>   - Add unit tests for notifier (config gating, send, retries) and webhook handler (auth, JSON validation, create/delete idempotency).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d099ae77cfc4e4a96ab78eb789e2ca76df5584f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->