### PR TITLE
Fix GitHub Issue #206

### DIFF
--- a/packages/web/e2e/auth-integration.spec.ts
+++ b/packages/web/e2e/auth-integration.spec.ts
@@ -133,7 +133,8 @@ test.describe('Authentication Integration E2E', () => {
     await page.click('button[type="submit"]')
 
     // Should show error message and stay on login page
-    await expect(page.locator('text=Invalid email or password')).toBeVisible()
+    // Wait for the error message to appear (with increased timeout for network request)
+    await expect(page.locator('text=Invalid email or password')).toBeVisible({ timeout: 10000 })
     await expect(page).toHaveURL(/\/login/)
 
     // Form should still be functional
@@ -202,7 +203,7 @@ test.describe('Authentication Integration E2E', () => {
     await page.click('button[type="submit"]')
 
     // Should show password mismatch error
-    await expect(page.locator('text=Passwords do not match')).toBeVisible()
+    await expect(page.locator('text=Passwords do not match')).toBeVisible({ timeout: 5000 })
 
     // Test short password
     await page.fill('input[name="password"]', '123')
@@ -210,7 +211,9 @@ test.describe('Authentication Integration E2E', () => {
     await page.click('button[type="submit"]')
 
     // Should show password length error
-    await expect(page.locator('text=Password must be at least 8 characters')).toBeVisible()
+    await expect(page.locator('text=Password must be at least 8 characters')).toBeVisible({
+      timeout: 5000,
+    })
 
     // Test invalid email - this should trigger browser validation
     await page.fill('input[name="email"]', 'invalid-email')


### PR DESCRIPTION
Fixes issue #206 where E2E auth tests were failing due to timing issues when checking for error messages.

Changes:
- Added 10s timeout for "Invalid email or password" error message check to handle network request delay (line 137)
- Added 5s timeouts for client-side validation error messages ("Passwords do not match" and "Password must be at least 8 characters") to handle potential rendering delays

These timeouts ensure the tests wait for async operations and rendering to complete before asserting that error messages are visible, improving test reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase Playwright visibility timeouts for auth error messages to reduce flakiness in auth E2E tests.
> 
> - **E2E/Auth tests (`packages/web/e2e/auth-integration.spec.ts`)**:
>   - Increase visibility timeout to `10000ms` for `Invalid email or password` on login.
>   - Add `5000ms` visibility timeouts for signup validation errors: `Passwords do not match` and `Password must be at least 8 characters`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80f631b99dc6f9a8c27ff4051380b159f7163bed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->