### PR TITLE
Switch to Claude 4.5 Sonnet and Haiku

### DIFF
--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -6,8 +6,8 @@ export interface SupportedModel {
 }
 
 export const MODEL_IDS = {
-  CLAUDE_SONNET: 'claude-sonnet-4-20250514',
-  CLAUDE_OPUS: 'claude-opus-4-1-20250805',
+  CLAUDE_SONNET: 'claude-sonnet-4-5-20250929',
+  CLAUDE_HAIKU: 'claude-haiku-4-5-20251001',
   GPT_5: 'gpt-5-2025-08-07',
   O3: 'o3-2025-04-16',
 } as const
@@ -17,15 +17,15 @@ export type ModelId = (typeof MODEL_IDS)[keyof typeof MODEL_IDS]
 export const supportedModels: SupportedModel[] = [
   {
     id: MODEL_IDS.CLAUDE_SONNET,
-    name: 'Claude 4 Sonnet',
+    name: 'Claude 4.5 Sonnet',
     provider: 'anthropic',
-    description: 'Fast, intelligent model for most tasks',
+    description: 'Balanced model for high-quality general tasks',
   },
   {
-    id: MODEL_IDS.CLAUDE_OPUS,
-    name: 'Claude 4.1 Opus',
+    id: MODEL_IDS.CLAUDE_HAIKU,
+    name: 'Claude 4.5 Haiku',
     provider: 'anthropic',
-    description: 'Most capable model for complex tasks',
+    description: 'Fastest Claude 4.5 model for lightweight tasks',
   },
   {
     id: MODEL_IDS.GPT_5,
@@ -41,7 +41,9 @@ export const supportedModels: SupportedModel[] = [
   },
 ]
 
-export const DEFAULT_MODEL = MODEL_IDS.CLAUDE_SONNET
+export const DEFAULT_MODEL_STRING = MODEL_IDS.CLAUDE_SONNET
+
+export const DEFAULT_MODEL: ModelId = DEFAULT_MODEL_STRING
 
 export const getModelById = (modelId: string): SupportedModel | undefined => {
   return supportedModels.find(model => model.id === modelId)

--- a/packages/web/src/components/chat/ChatPresenter/ChatPresenter.stories.tsx
+++ b/packages/web/src/components/chat/ChatPresenter/ChatPresenter.stories.tsx
@@ -8,6 +8,7 @@ import {
   getWorkers$,
 } from '@work-squared/shared/queries'
 import { schema, events, type Worker } from '@work-squared/shared/schema'
+import { DEFAULT_MODEL_STRING } from '@work-squared/shared'
 import { LiveStoreProvider, useQuery } from '@livestore/react'
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
@@ -79,7 +80,7 @@ const storySetup = (store: Store) => {
       name: 'New Assistant',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -89,7 +90,7 @@ const storySetup = (store: Store) => {
       id: '1',
       title: 'Conversation with New Assistant',
       createdAt: new Date(),
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       workerId: '1',
     })
   )
@@ -144,7 +145,7 @@ const withConversationsSetup = (store: Store) => {
       avatar: '✨',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -152,7 +153,7 @@ const withConversationsSetup = (store: Store) => {
     events.conversationCreated({
       id: '1',
       title: 'Conversation with Sample Assistant',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date(),
       workerId: '1',
     })
@@ -200,7 +201,7 @@ const processingSetup = (store: Store) => {
       avatar: '⚡',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -208,7 +209,7 @@ const processingSetup = (store: Store) => {
     events.conversationCreated({
       id: '1',
       title: 'Processing Conversation',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date(),
       workerId: '1',
     })
@@ -267,7 +268,7 @@ const chatPickerSetup = (store: Store) => {
       avatar: '🤖',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -279,7 +280,7 @@ const chatPickerSetup = (store: Store) => {
       roleDescription: 'Specialized in code reviews',
       createdAt: new Date(),
       systemPrompt: 'You are a code review specialist.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -291,7 +292,7 @@ const chatPickerSetup = (store: Store) => {
       roleDescription: 'Project planning and management',
       createdAt: new Date(),
       systemPrompt: 'You are a project management expert.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -299,7 +300,7 @@ const chatPickerSetup = (store: Store) => {
     events.conversationCreated({
       id: '1',
       title: 'Sample Conversation',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date(),
       workerId: '1',
     })
@@ -331,7 +332,7 @@ const longConversationSetup = (store: Store) => {
       avatar: '💬',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -339,7 +340,7 @@ const longConversationSetup = (store: Store) => {
     events.conversationCreated({
       id: '1',
       title: 'Long Conversation',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date(),
       workerId: '1',
     })

--- a/packages/web/src/components/chat/ChatPresenter/ChatPresenter.test.tsx
+++ b/packages/web/src/components/chat/ChatPresenter/ChatPresenter.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { ChatPresenter } from './ChatPresenter.js'
 import type { ChatMessage, Conversation, Worker } from '@work-squared/shared/schema'
+import { DEFAULT_MODEL_STRING } from '@work-squared/shared'
 
 // Mock scrollIntoView for tests
 Object.defineProperty(window.Element.prototype, 'scrollIntoView', {
@@ -17,7 +18,7 @@ describe('ChatPresenter', () => {
     avatar: '🤖',
     roleDescription: 'AI Assistant',
     systemPrompt: 'Be helpful',
-    defaultModel: 'claude-sonnet-4-20250514',
+    defaultModel: DEFAULT_MODEL_STRING,
     isActive: true,
     createdAt: new Date('2024-01-01T00:00:00Z'),
     updatedAt: null,
@@ -28,7 +29,7 @@ describe('ChatPresenter', () => {
     title: 'Strategy Session',
     createdAt: new Date('2024-01-01T01:00:00Z'),
     updatedAt: new Date('2024-01-01T01:05:00Z'),
-    model: 'claude-sonnet-4-20250514',
+    model: DEFAULT_MODEL_STRING,
     workerId: 'worker-1',
     processingState: 'idle',
   }

--- a/packages/web/src/components/chat/MessageList/MessageList.stories.tsx
+++ b/packages/web/src/components/chat/MessageList/MessageList.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { MessageList } from './MessageList.js'
 import { getConversationMessages$, getWorkerById$ } from '@work-squared/shared/queries'
 import { schema, events } from '@work-squared/shared/schema'
+import { DEFAULT_MODEL_STRING } from '@work-squared/shared'
 import { LiveStoreProvider, useQuery } from '@livestore/react'
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
@@ -74,7 +75,7 @@ const basicMessagesSetup = (store: Store) => {
       avatar: '☀️',
       roleDescription: 'Project Manager',
       systemPrompt: 'You are a helpful project management assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       createdAt: new Date('2024-01-01'),
       actorId: '1',
     })
@@ -83,7 +84,7 @@ const basicMessagesSetup = (store: Store) => {
     events.conversationCreated({
       id: 'conv1',
       title: 'Test Conversation',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date('2025-01-01T12:00:00'),
       workerId: 'worker-1',
     })
@@ -127,7 +128,7 @@ const toolCallMessagesSetup = (store: Store) => {
       avatar: '☀️',
       roleDescription: 'Project Manager',
       systemPrompt: 'You are a helpful project management assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       createdAt: new Date('2024-01-01'),
       actorId: '1',
     })
@@ -136,7 +137,7 @@ const toolCallMessagesSetup = (store: Store) => {
     events.conversationCreated({
       id: 'conv1',
       title: 'Tool Call Example',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date('2025-01-01T12:00:00'),
       workerId: 'worker-1',
     })
@@ -189,7 +190,7 @@ const processingSetup = (store: Store) => {
       avatar: '☀️',
       roleDescription: 'Project Manager',
       systemPrompt: 'You are a helpful project management assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       createdAt: new Date('2024-01-01'),
       actorId: '1',
     })
@@ -198,7 +199,7 @@ const processingSetup = (store: Store) => {
     events.conversationCreated({
       id: 'conv1',
       title: 'Processing...',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date('2025-01-01T12:00:00'),
       workerId: 'worker-1',
     })
@@ -242,7 +243,7 @@ const emptySetup = (store: Store) => {
       avatar: '☀️',
       roleDescription: 'Project Manager',
       systemPrompt: 'You are a helpful project management assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       createdAt: new Date('2024-01-01'),
       actorId: '1',
     })
@@ -251,7 +252,7 @@ const emptySetup = (store: Store) => {
     events.conversationCreated({
       id: 'conv1',
       title: 'New Conversation',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date('2025-01-01T12:00:00'),
       workerId: 'worker-1',
     })
@@ -276,7 +277,7 @@ const longConversationSetup = (store: Store) => {
       avatar: '☀️',
       roleDescription: 'Project Manager',
       systemPrompt: 'You are a helpful project management assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       createdAt: new Date('2024-01-01'),
       actorId: '1',
     })
@@ -285,7 +286,7 @@ const longConversationSetup = (store: Store) => {
     events.conversationCreated({
       id: 'conv1',
       title: 'Long Conversation',
-      model: 'claude-sonnet-4-20250514',
+      model: DEFAULT_MODEL_STRING,
       createdAt: new Date('2025-01-01T12:00:00'),
       workerId: 'worker-1',
     })

--- a/packages/web/src/components/projects/ProjectCard/ProjectCard.stories.tsx
+++ b/packages/web/src/components/projects/ProjectCard/ProjectCard.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { ProjectCard } from './ProjectCard.js'
 import { getProjects$ } from '@work-squared/shared/queries'
 import { schema, events } from '@work-squared/shared/schema'
+import { DEFAULT_MODEL_STRING } from '@work-squared/shared'
 import { LiveStoreProvider, useQuery } from '@livestore/react'
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
@@ -93,7 +94,7 @@ const withTeamSetup = (store: Store) => {
       avatar: '👩‍💼',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -104,7 +105,7 @@ const withTeamSetup = (store: Store) => {
       avatar: '👨‍💻',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -115,7 +116,7 @@ const withTeamSetup = (store: Store) => {
       avatar: '👩‍🎨',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )
@@ -183,7 +184,7 @@ const largeTeamSetup = (store: Store) => {
         avatar: worker.avatar,
         createdAt: new Date(),
         systemPrompt: 'You are a helpful assistant.',
-        defaultModel: 'claude-sonnet-4-20250514',
+        defaultModel: DEFAULT_MODEL_STRING,
         actorId: '1',
       })
     )
@@ -222,7 +223,7 @@ const longNameSetup = (store: Store) => {
       avatar: '👩‍💼',
       createdAt: new Date(),
       systemPrompt: 'You are a helpful assistant.',
-      defaultModel: 'claude-sonnet-4-20250514',
+      defaultModel: DEFAULT_MODEL_STRING,
       actorId: '1',
     })
   )

--- a/packages/web/src/components/ui/ModelSelector/ModelSelector.test.tsx
+++ b/packages/web/src/components/ui/ModelSelector/ModelSelector.test.tsx
@@ -28,8 +28,8 @@ describe('ModelSelector', () => {
     render(<ModelSelector selectedModel={DEFAULT_MODEL} onModelChange={onModelChange} />)
 
     // Check that all models are available as options
-    expect(screen.getByRole('option', { name: 'Claude 4 Sonnet' })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: 'Claude 4.1 Opus' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Claude 4.5 Sonnet' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Claude 4.5 Haiku' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'GPT-5' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'OpenAI O3' })).toBeInTheDocument()
   })

--- a/packages/web/src/components/workers/CreateWorkerModal/CreateWorkerModal.test.tsx
+++ b/packages/web/src/components/workers/CreateWorkerModal/CreateWorkerModal.test.tsx
@@ -35,7 +35,8 @@ vi.mock('../../ui/ModelSelector/ModelSelector.js', () => ({
       value={selectedModel}
       onChange={e => onModelChange(e.target.value)}
     >
-      <option value={MODEL_IDS.CLAUDE_SONNET}>Claude 4 Sonnet</option>
+      <option value={MODEL_IDS.CLAUDE_SONNET}>Claude 4.5 Sonnet</option>
+      <option value={MODEL_IDS.CLAUDE_HAIKU}>Claude 4.5 Haiku</option>
       <option value={MODEL_IDS.GPT_5}>GPT-5</option>
     </select>
   ),

--- a/packages/web/src/utils/models.test.ts
+++ b/packages/web/src/utils/models.test.ts
@@ -8,14 +8,14 @@ import {
 } from './models.js'
 
 describe('Models utility', () => {
-  it('should have claude-sonnet-4-20250514 as default model', () => {
+  it('should default to the Sonnet model ID', () => {
     expect(DEFAULT_MODEL).toBe(MODEL_IDS.CLAUDE_SONNET)
   })
 
   it('should get model by ID', () => {
     const model = getModelById(MODEL_IDS.CLAUDE_SONNET)
     expect(model).toBeDefined()
-    expect(model?.name).toBe('Claude 4 Sonnet')
+    expect(model?.name).toBe('Claude 4.5 Sonnet')
     expect(model?.provider).toBe('anthropic')
   })
 
@@ -26,6 +26,7 @@ describe('Models utility', () => {
 
   it('should validate model IDs correctly', () => {
     expect(isValidModelId(MODEL_IDS.CLAUDE_SONNET)).toBe(true)
+    expect(isValidModelId(MODEL_IDS.CLAUDE_HAIKU)).toBe(true)
     expect(isValidModelId(MODEL_IDS.GPT_5)).toBe(true)
     expect(isValidModelId(MODEL_IDS.O3)).toBe(true)
     expect(isValidModelId('invalid-model')).toBe(false)
@@ -34,7 +35,7 @@ describe('Models utility', () => {
   it('should include all expected models', () => {
     const modelIds = supportedModels.map(m => m.id)
     expect(modelIds).toContain(MODEL_IDS.CLAUDE_SONNET)
-    expect(modelIds).toContain(MODEL_IDS.CLAUDE_OPUS)
+    expect(modelIds).toContain(MODEL_IDS.CLAUDE_HAIKU)
     expect(modelIds).toContain(MODEL_IDS.GPT_5)
     expect(modelIds).toContain(MODEL_IDS.O3)
   })

--- a/packages/web/src/utils/models.ts
+++ b/packages/web/src/utils/models.ts
@@ -1,6 +1,7 @@
 export {
   MODEL_IDS,
   DEFAULT_MODEL,
+  DEFAULT_MODEL_STRING,
   supportedModels,
   getModelById,
   isValidModelId,


### PR DESCRIPTION
## Summary
- update shared Anthropic model IDs to Claude 4.5 Sonnet and add Claude 4.5 Haiku
- remove Claude 4.1 Opus references across docs, tests, and Storybook fixtures
- refresh UI tests to expect the new options and keep defaults on Claude 4.5 Sonnet

## Testing
- pnpm lint-all
- pnpm test
- CI=true pnpm test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update supported models to Claude 4.5 Sonnet (default) and 4.5 Haiku, removing Opus and aligning stories/tests and exports.
> 
> - **Models (shared)**:
>   - Update `MODEL_IDS`: set `CLAUDE_SONNET` to `claude-sonnet-4-5-20250929`; add `CLAUDE_HAIKU` `claude-haiku-4-5-20251001`; keep `GPT_5`, `O3`.
>   - Update `supportedModels` names/descriptions to "Claude 4.5 Sonnet" and "Claude 4.5 Haiku".
>   - Introduce `DEFAULT_MODEL_STRING` and export typed `DEFAULT_MODEL: ModelId = DEFAULT_MODEL_STRING` (defaulting to Sonnet).
> - **Web utils**:
>   - Re-export `DEFAULT_MODEL_STRING` and updated model utilities from `@work-squared/shared`.
> - **Stories (UI)**:
>   - Replace hardcoded model IDs with `DEFAULT_MODEL_STRING` in `ChatPresenter.stories.tsx`, `MessageList.stories.tsx`, `ProjectCard.stories.tsx`.
> - **Tests**:
>   - Update expectations to new model names/options and IDs in `ModelSelector.test.tsx`, `CreateWorkerModal.test.tsx`, `ChatPresenter.test.tsx`, `utils/models.test.ts` (including validation for `CLAUDE_HAIKU`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 049bb54dbe2d168be4bfece08de936b62c828998. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->