### PR TITLE
Add new UI foundation for projects

### DIFF
--- a/packages/web/src/Root.tsx
+++ b/packages/web/src/Root.tsx
@@ -34,6 +34,9 @@ import { SettingsInitializer } from './components/utils/SettingsInitializer/Sett
 import { LifeMapView } from './components/life-map/LifeMapView.js'
 import { schema } from '@work-squared/shared/schema'
 import { ROUTES } from './constants/routes.js'
+import { ProjectsListPage } from './components/new/projects/ProjectsListPage.js'
+import { ProjectDetailPage } from './components/new/projects/ProjectDetailPage.js'
+import { NewUiShell } from './components/new/layout/NewUiShell.js'
 
 const adapter = makePersistedAdapter({
   storage: { type: 'opfs' },
@@ -160,6 +163,16 @@ const ProtectedApp: React.FC = () => {
                       }
                     />
                     <Route
+                      path={ROUTES.NEW_PROJECTS}
+                      element={
+                        <ErrorBoundary>
+                          <NewUiShell>
+                            <ProjectsListPage />
+                          </NewUiShell>
+                        </ErrorBoundary>
+                      }
+                    />
+                    <Route
                       path={ROUTES.TASKS}
                       element={
                         <Layout>
@@ -247,6 +260,16 @@ const ProtectedApp: React.FC = () => {
                             <ProjectWorkspace />
                           </ErrorBoundary>
                         </Layout>
+                      }
+                    />
+                    <Route
+                      path={ROUTES.NEW_PROJECT}
+                      element={
+                        <ErrorBoundary>
+                          <NewUiShell>
+                            <ProjectDetailPage />
+                          </NewUiShell>
+                        </ErrorBoundary>
                       }
                     />
                     <Route

--- a/packages/web/src/components/new/README.md
+++ b/packages/web/src/components/new/README.md
@@ -1,0 +1,18 @@
+# New UI Components
+
+This directory contains the in-progress reimplementation of the Work Squared interface. Pages and components that live here are intentionally minimal – their primary goal is to establish routing, data-fetching patterns, and baseline rendering for the new `/new` route hierarchy.
+
+## Structure
+
+- `projects/` – Foundations for the new Projects list and Project detail experiences.
+- `layout/` – Lightweight shells used to keep new surfaces independent from the legacy navbar/chat chrome.
+
+## Guidelines
+
+- Follow the requirements outlined in `docs/plans/026-new-ui-foundation/plan.md`.
+- Use real LiveStore data via `useQuery` hooks; avoid mock data outside of Storybook boot functions.
+- Prefer small, focused components that can evolve into the future design system.
+- Continue to preserve the `storeId` query parameter via `preserveStoreIdInUrl` when linking between routes.
+- Route-level shells (e.g., `NewUiShell`) should not pull in legacy layout primitives; they are responsible for providing only the minimal spacing/background baseline the new UI needs.
+
+These guidelines will evolve as additional plans land; keep this README up to date as new directories are added.

--- a/packages/web/src/components/new/layout/NewUiShell.tsx
+++ b/packages/web/src/components/new/layout/NewUiShell.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+type NewUiShellProps = {
+  children: React.ReactNode
+}
+
+/**
+ * Minimal shell for the next-generation UI surfaces.
+ * Keeps legacy navigation/chat chrome out of new routes while providing
+ * a consistent canvas and spacing baseline.
+ */
+export const NewUiShell: React.FC<NewUiShellProps> = ({ children }) => {
+  return (
+    <div className='min-h-screen bg-white text-gray-900'>
+      <main className='mx-auto w-full max-w-5xl px-6 py-8 space-y-8'>{children}</main>
+    </div>
+  )
+}

--- a/packages/web/src/components/new/projects/ProjectDetailPage.stories.tsx
+++ b/packages/web/src/components/new/projects/ProjectDetailPage.stories.tsx
@@ -1,0 +1,232 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
+import { Routes, Route } from 'react-router-dom'
+import { LiveStoreProvider } from '@livestore/react'
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
+import { Store } from '@livestore/livestore'
+import { schema, events } from '@work-squared/shared/schema'
+import { ProjectDetailPage } from './ProjectDetailPage.js'
+
+type TaskSeed = {
+  id: string
+  title: string
+  status?: 'todo' | 'doing' | 'in_review' | 'done'
+  assigneeIds?: string[]
+  description?: string
+  commentCount?: number
+}
+
+const withProjectProviders =
+  (projectId: string, boot?: (store: Store) => void) =>
+  (Story: React.ComponentType): React.ReactElement => {
+    if (typeof window !== 'undefined') {
+      window.history.replaceState({}, '', `/new/projects/${projectId}`)
+    }
+
+    return (
+      <LiveStoreProvider
+        schema={schema}
+        adapter={makeInMemoryAdapter()}
+        batchUpdates={batchUpdates}
+        boot={store => {
+          boot?.(store)
+        }}
+      >
+        <Routes>
+          <Route path='/new/projects/:projectId' element={<Story />} />
+        </Routes>
+      </LiveStoreProvider>
+    )
+  }
+
+const seedUsers = (store: Store) => {
+  const now = new Date('2024-01-01T00:00:00Z')
+  const users = [
+    { id: 'user-1', name: 'Alice Adams', email: 'alice@example.com' },
+    { id: 'user-2', name: 'Brandon Brooks', email: 'brandon@example.com' },
+    { id: 'user-3', name: 'Casey Chen', email: 'casey@example.com' },
+  ]
+
+  users.forEach(user => {
+    store.commit(
+      events.userSynced({
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        avatarUrl: undefined,
+        isAdmin: false,
+        syncedAt: now,
+      })
+    )
+  })
+}
+
+const seedProject = (store: Store, projectId: string, name: string, description?: string) => {
+  store.commit(
+    events.projectCreated({
+      id: projectId,
+      name,
+      description,
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      actorId: 'storybook',
+    })
+  )
+}
+
+const makeTaskSeeder = (store: Store, projectId: string) => {
+  let positionCounter = 1
+  return (task: TaskSeed) => {
+    store.commit(
+      events.taskCreatedV2({
+        id: task.id,
+        projectId,
+        title: task.title,
+        description: task.description,
+        status: task.status ?? 'todo',
+        assigneeIds: task.assigneeIds,
+        attributes: undefined,
+        position: positionCounter++,
+        createdAt: new Date('2024-01-02T00:00:00Z'),
+        actorId: 'storybook',
+      })
+    )
+
+    if (task.commentCount && task.commentCount > 0) {
+      for (let i = 0; i < task.commentCount; i += 1) {
+        store.commit(
+          events.commentAdded({
+            id: `${task.id}-comment-${i + 1}`,
+            taskId: task.id,
+            authorId: task.assigneeIds?.[0] ?? 'user-1',
+            content: `Comment ${i + 1} on ${task.title}`,
+            createdAt: new Date('2024-01-03T00:00:00Z'),
+            actorId: 'storybook',
+          })
+        )
+      }
+    }
+  }
+}
+
+const meta: Meta<typeof ProjectDetailPage> = {
+  title: 'New UI/Projects/ProjectDetailPage',
+  component: ProjectDetailPage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Baseline project detail page that lists high-level project data and a simple task list.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const defaultSetup = (store: Store) => {
+  const projectId = 'project-default'
+  seedUsers(store)
+  seedProject(store, projectId, 'New UI Foundation', 'Baseline project used by the new UI.')
+  const addTask = makeTaskSeeder(store, projectId)
+
+  addTask({
+    id: 'task-1',
+    title: 'Gather project requirements',
+    status: 'todo',
+    assigneeIds: ['user-1'],
+    description: 'Document the initial requirements for the redesign.',
+    commentCount: 2,
+  })
+  addTask({
+    id: 'task-2',
+    title: 'Define routing plan',
+    status: 'doing',
+    assigneeIds: ['user-2', 'user-3'],
+    description: 'List new routes and data requirements.',
+  })
+  addTask({
+    id: 'task-3',
+    title: 'Implement LiveStore queries',
+    status: 'in_review',
+    assigneeIds: ['user-1'],
+    commentCount: 1,
+  })
+  addTask({
+    id: 'task-4',
+    title: 'Document new UI directory structure',
+    status: 'done',
+    assigneeIds: [],
+  })
+  addTask({
+    id: 'task-5',
+    title: 'Plan Storybook coverage',
+    status: 'todo',
+    assigneeIds: ['user-3'],
+  })
+}
+
+const emptyProjectSetup = (store: Store) => {
+  seedUsers(store)
+  seedProject(store, 'project-empty', 'Empty Project', 'No tasks seeded yet.')
+}
+
+const singleTaskSetup = (store: Store) => {
+  const projectId = 'project-single-task'
+  seedUsers(store)
+  seedProject(store, projectId, 'Single Task Project', 'Contains exactly one task.')
+  const addTask = makeTaskSeeder(store, projectId)
+
+  addTask({
+    id: 'task-lone',
+    title: 'Stand-alone task',
+    status: 'doing',
+    assigneeIds: ['user-2'],
+    description: 'Simple example task with both description and comments.',
+    commentCount: 3,
+  })
+}
+
+const manyTasksSetup = (store: Store) => {
+  const projectId = 'project-many'
+  seedUsers(store)
+  seedProject(store, projectId, 'Many Tasks Project', 'Used to visualize longer lists.')
+  const addTask = makeTaskSeeder(store, projectId)
+  const statuses: TaskSeed['status'][] = ['todo', 'doing', 'in_review', 'done']
+
+  for (let i = 0; i < 20; i += 1) {
+    addTask({
+      id: `task-${i + 1}`,
+      title: `Task ${i + 1}`,
+      status: statuses[i % statuses.length],
+      assigneeIds: i % 3 === 0 ? ['user-1', 'user-3'] : ['user-2'],
+      commentCount: i % 4 === 0 ? 1 : 0,
+    })
+  }
+}
+
+export const Default: Story = {
+  decorators: [withProjectProviders('project-default', defaultSetup)],
+}
+
+export const EmptyState: Story = {
+  decorators: [withProjectProviders('project-empty', emptyProjectSetup)],
+}
+
+export const SingleTask: Story = {
+  decorators: [withProjectProviders('project-single-task', singleTaskSetup)],
+}
+
+export const ManyTasks: Story = {
+  decorators: [withProjectProviders('project-many', manyTasksSetup)],
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates how the page handles projects with large task counts.',
+      },
+    },
+  },
+}

--- a/packages/web/src/components/new/projects/ProjectDetailPage.tsx
+++ b/packages/web/src/components/new/projects/ProjectDetailPage.tsx
@@ -1,0 +1,99 @@
+import React, { useMemo } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useQuery } from '@livestore/react'
+import {
+  getProjectById$,
+  getProjectTasks$,
+  getUsers$,
+  getTaskComments$,
+} from '@work-squared/shared/queries'
+import type { Project, Task, User } from '@work-squared/shared/schema'
+import { ROUTES } from '../../../constants/routes.js'
+import { preserveStoreIdInUrl } from '../../../utils/navigation.js'
+
+const parseAssigneeIds = (raw: string | null | undefined): string[] => {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+type UsersById = Map<string, User>
+
+const TaskListItem: React.FC<{ task: Task; usersById: UsersById }> = ({ task, usersById }) => {
+  const comments = useQuery(getTaskComments$(task.id)) ?? []
+  const assigneeIds = parseAssigneeIds(task.assigneeIds)
+  const assignees = assigneeIds
+    .map(id => usersById.get(id))
+    .filter((user): user is User => Boolean(user))
+  const assigneeNames = assignees.map(user => user.name || user.email || user.id)
+  const hasDescription = Boolean(task.description && task.description.trim().length > 0)
+  const hasComments = comments.length > 0
+
+  return (
+    <li>
+      <div>
+        <strong>{task.title || 'Untitled task'}</strong>
+        <span> [{task.status}]</span>
+      </div>
+      <div>
+        <span>Assignees: {assigneeNames.length > 0 ? assigneeNames.join(', ') : 'Unassigned'}</span>
+        {hasDescription && <span> 📝</span>}
+        {hasComments && <span> 💬 ({comments.length})</span>}
+      </div>
+      {task.description && (
+        <div>
+          <small>{task.description}</small>
+        </div>
+      )}
+    </li>
+  )
+}
+
+export const ProjectDetailPage: React.FC = () => {
+  const { projectId } = useParams<{ projectId: string }>()
+  const resolvedProjectId = projectId ?? '__invalid__'
+  const projectRows = useQuery(getProjectById$(resolvedProjectId)) ?? []
+  const tasks = useQuery(getProjectTasks$(resolvedProjectId)) ?? []
+  const users = useQuery(getUsers$) ?? []
+  const usersById = useMemo(() => new Map(users.map(user => [user.id, user])), [users])
+  const project = (projectRows[0] ?? undefined) as Project | undefined
+
+  return (
+    <div>
+      <Link to={preserveStoreIdInUrl(ROUTES.NEW_PROJECTS)}>← Back to projects</Link>
+
+      {!projectId ? (
+        <p>Invalid project ID</p>
+      ) : !project ? (
+        <div>
+          <h1>Project not found</h1>
+          <p>The requested project ({projectId}) does not exist.</p>
+        </div>
+      ) : (
+        <div>
+          <header>
+            <h1>{project.name || 'Untitled project'}</h1>
+            {project.description && <p>{project.description}</p>}
+          </header>
+
+          <section>
+            <h2>Tasks</h2>
+            {tasks.length === 0 ? (
+              <p>No tasks in this project</p>
+            ) : (
+              <ul>
+                {tasks.map(task => (
+                  <TaskListItem key={task.id} task={task} usersById={usersById} />
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/new/projects/ProjectsListPage.stories.tsx
+++ b/packages/web/src/components/new/projects/ProjectsListPage.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
+import { LiveStoreProvider } from '@livestore/react'
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
+import { Store } from '@livestore/livestore'
+import { schema, events } from '@work-squared/shared/schema'
+import { ProjectsListPage } from './ProjectsListPage.js'
+
+const withProviders =
+  (boot?: (store: Store) => void) =>
+  (Story: React.ComponentType): React.ReactElement => {
+    if (typeof window !== 'undefined') {
+      window.history.replaceState({}, '', '/new/projects')
+    }
+
+    return (
+      <LiveStoreProvider
+        schema={schema}
+        adapter={makeInMemoryAdapter()}
+        batchUpdates={batchUpdates}
+        boot={store => {
+          boot?.(store)
+        }}
+      >
+        <Story />
+      </LiveStoreProvider>
+    )
+  }
+
+const meta: Meta<typeof ProjectsListPage> = {
+  title: 'New UI/Projects/ProjectsListPage',
+  component: ProjectsListPage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'Foundational list of projects used by the new UI routing stack.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const createProjects = (store: Store, count: number) => {
+  const baseDate = new Date('2024-01-01T00:00:00Z').getTime()
+  for (let i = 0; i < count; i += 1) {
+    const index = i + 1
+    store.commit(
+      events.projectCreated({
+        id: `project-${index}`,
+        name: `Project ${index}`,
+        description: `Seeded project ${index} for Storybook state.`,
+        createdAt: new Date(baseDate + i * 86_400_000),
+        actorId: 'storybook',
+      })
+    )
+  }
+}
+
+export const Default: Story = {
+  decorators: [
+    withProviders(store => {
+      createProjects(store, 5)
+    }),
+  ],
+}
+
+export const SingleProject: Story = {
+  decorators: [
+    withProviders(store => {
+      createProjects(store, 1)
+    }),
+  ],
+}
+
+export const EmptyState: Story = {
+  decorators: [withProviders()],
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates how the page behaves when no projects have been created yet.',
+      },
+    },
+  },
+}

--- a/packages/web/src/components/new/projects/ProjectsListPage.tsx
+++ b/packages/web/src/components/new/projects/ProjectsListPage.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { useQuery } from '@livestore/react'
+import { getProjects$ } from '@work-squared/shared/queries'
+import { generateRoute } from '../../../constants/routes.js'
+import { preserveStoreIdInUrl } from '../../../utils/navigation.js'
+
+export const ProjectsListPage: React.FC = () => {
+  const projects = useQuery(getProjects$) ?? []
+
+  return (
+    <div>
+      <header>
+        <h1>Projects</h1>
+        <p>Foundation list for the upcoming UI. Links navigate to the new project detail page.</p>
+      </header>
+
+      {projects.length === 0 ? (
+        <p>No projects yet</p>
+      ) : (
+        <ul>
+          {projects.map(project => (
+            <li key={project.id}>
+              <Link to={preserveStoreIdInUrl(generateRoute.newProject(project.id))}>
+                {project.name || 'Untitled project'}
+              </Link>
+              {project.description && <p>{project.description}</p>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/constants/routes.ts
+++ b/packages/web/src/constants/routes.ts
@@ -7,6 +7,8 @@ export const ROUTES = {
   LIFE_MAP: '/life-map',
   CATEGORY: '/category/:categoryId',
   PROJECTS: '/projects',
+  NEW_PROJECTS: '/new/projects',
+  NEW_PROJECT: '/new/projects/:projectId',
   TASKS: '/tasks',
   TEAM: '/team',
   DOCUMENTS: '/documents',
@@ -29,6 +31,7 @@ export const generateRoute = {
   category: (id: string, tab?: string) => (tab ? `/category/${id}?tab=${tab}` : `/category/${id}`),
   document: (id: string) => `/document/${id}`,
   project: (id: string) => `/project/${id}`,
+  newProject: (id: string) => `/new/projects/${id}`,
   contact: (id: string) => `/contacts/${id}`,
   adminUser: (userEmail: string) => `/admin/users/${encodeURIComponent(userEmail)}`,
 } as const


### PR DESCRIPTION
## Summary\n- add the /new/projects route hierarchy (list + detail) behind the existing Layout/ErrorBoundary/auth shell so the upcoming UI can be exercised without touching legacy pages\n- scaffold a dedicated `components/new` namespace with README guidance, LiveStore-backed list/detail components, and storeId-preserving navigation\n- seed Storybook coverage for both pages using real events/users/tasks/comments while keeping routing compatible with the global BrowserRouter\n\n## Testing\n- pnpm lint-all\n- pnpm test\n- CI=true pnpm test:e2e\n- gh pr checks 316

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces LiveStore-backed `/new/projects` list and detail pages with a lightweight `NewUiShell`, wired into routing and covered by Storybook.
> 
> - **Frontend (New UI foundation)**
>   - **Layout**: Add minimal `NewUiShell` in `components/new/layout/NewUiShell.tsx`.
>   - **Projects**: Implement `ProjectsListPage` and `ProjectDetailPage` in `components/new/projects/` using LiveStore queries and storeId-preserving links.
>   - **Storybook**: Add stories for list and detail pages with seeded users/projects/tasks/comments.
> - **Routing**
>   - Add `ROUTES.NEW_PROJECTS` and `ROUTES.NEW_PROJECT` plus `generateRoute.newProject` in `constants/routes.ts`.
>   - Wire new routes in `Root.tsx` under `ErrorBoundary`, rendering pages inside `NewUiShell`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 386c48d8d4ff8d2d5ce4a8adb3434a4dd43b7c73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->