### PR TITLE
Fix markdown formatting in docs

### DIFF
--- a/docs/adrs/008-distributed-security-policy.md
+++ b/docs/adrs/008-distributed-security-policy.md
@@ -41,17 +41,20 @@ Adopt a “distributed claims + version map” policy:
 ## Consequences
 
 **Positives**
+
 - Per-connection workspace validation no longer hits the Auth Worker Durable Object, eliminating the largest source of DO duration usage.
 - Revocation is deterministic: bump version → write KV → clients with stale tokens are rejected immediately.
 - Each component can continue operating even if another is degraded, as long as JWT signing keys remain trusted.
 - Operational load drops because there is no need to reconcile caches or restart services after membership changes.
 
 **Negatives / Trade-offs**
+
 - Requires additional infrastructure (Cloudflare KV) and careful consistency handling between DO storage and KV.
 - Bugs in version increment logic could allow stale tokens to persist until JWT expiry.
 - Clients must implement refresh-on-rejection flows to recover gracefully when versions mismatch.
 
 **Follow-up Actions**
+
 - Implement the JWT claim + version map plan (Plan 031).
 - Update deployment runbooks to include KV namespace provisioning and secret rotation procedures.
 - Instrument dashboards to track JWT claim sizes, version skew, and rejection rates.

--- a/docs/plans/026-new-ui-foundation/plan.md
+++ b/docs/plans/026-new-ui-foundation/plan.md
@@ -26,6 +26,7 @@ This plan establishes the foundation for a complete UI revamp of Work Squared. T
 ### Existing Project Page Structure
 
 Need to examine:
+
 - Current routing setup
 - How projects are currently queried
 - How tasks are currently displayed
@@ -42,6 +43,7 @@ Need to examine:
 ## Technical Implementation Plan
 
 1. **Create new directory structure:**
+
    ```
    packages/web/src/components/new/
    ├── projects/
@@ -120,11 +122,13 @@ All queries are already implemented and ready to use:
 ### Data Fetching Strategy
 
 **Projects List Page:**
+
 ```typescript
 const projects = useQuery(getProjects$) ?? []
 ```
 
 **Project Detail Page:**
+
 ```typescript
 // Single queries - memoized by LiveStore
 const project = useQuery(getProjectById$(projectId))
@@ -134,9 +138,7 @@ const users = useQuery(getUsers$) ?? []
 // Client-side processing
 const enrichedTasks = tasks.map(task => {
   const assigneeIds = JSON.parse(task.assigneeIds || '[]') as string[]
-  const assignees = assigneeIds
-    .map(id => users.find(u => u.id === id))
-    .filter(Boolean)
+  const assignees = assigneeIds.map(id => users.find(u => u.id === id)).filter(Boolean)
   const comments = useQuery(getTaskComments$(task.id)) ?? []
 
   return {
@@ -153,12 +155,14 @@ Note: Each `useQuery` call is memoized by LiveStore, so querying comments for ea
 ## UI Specifications (Minimal)
 
 ### Projects List Page
+
 - Page title: "Projects"
 - Unordered list of project names
 - Each project links to `/new/projects/:projectId`
 - Empty state: "No projects yet"
 
 ### Project Detail Page
+
 - Back link to projects list
 - Project name as heading
 - Project description (if exists)
@@ -346,6 +350,7 @@ export const Default: Story = {
 ### React Router Architecture
 
 The app uses React Router v6 with the following structure:
+
 - **Main router:** `Root.tsx` exports the `<App>` component
 - **Component tree:** `<BrowserRouter>` → `<Routes>` → `<Route>` elements
 - **Protected routes:** Most routes are wrapped in `<ProtectedApp>` which includes `<LiveStoreProvider>`
@@ -354,6 +359,7 @@ The app uses React Router v6 with the following structure:
 ### Routes to Add
 
 **In `Root.tsx`** (inside the `<ProtectedApp>` Routes block):
+
 ```typescript
 <Route
   path={ROUTES.NEW_PROJECTS}
@@ -378,6 +384,7 @@ The app uses React Router v6 with the following structure:
 ```
 
 **In `constants/routes.ts`:**
+
 ```typescript
 export const ROUTES = {
   // ... existing routes
@@ -394,6 +401,7 @@ export const generateRoute = {
 ### Navigation Access
 
 For this foundation PR, the new pages are **accessed manually**:
+
 - Navigate directly to `/new/projects` in the browser
 - No sidebar/nav links added yet (future PR)
 - Use browser back/forward or the "Back to projects" link in the UI
@@ -401,6 +409,7 @@ For this foundation PR, the new pages are **accessed manually**:
 ## Task Display Fields
 
 Based on schema analysis, tasks have:
+
 - `title` - Main display
 - `status` - 'todo' | 'doing' | 'in_review' | 'done'
 - `assigneeIds` - JSON array of user IDs (need to look up names)
@@ -408,6 +417,7 @@ Based on schema analysis, tasks have:
 - Comments - Need to query comments table by taskId to check if any exist
 
 Display for each task:
+
 - Title
 - Status badge/text
 - Assignee name(s) (if any)
@@ -440,11 +450,13 @@ Display for each task:
 ## Risk Assessment
 
 **Low Risk:**
+
 - Creating new directory structure
 - Adding new routes
 - Basic data fetching with existing queries
 
 **Medium Risk:**
+
 - Storybook setup with LiveStore events (first time using this pattern extensively)
 
 **No Identified High Risks** - This is a straightforward foundation-laying PR

--- a/docs/plans/031-workspace-claims-in-jwt.md
+++ b/docs/plans/031-workspace-claims-in-jwt.md
@@ -120,6 +120,7 @@ Because we have no active production sessions, we can ship this as a single PR w
    - Document the provisioning commands in `docs/deployment.md` and ensure `pnpm install` steps don’t try to create namespaces automatically.
 
 **Testing / Validation**
+
 - Unit tests for new shared types, version bump logic, and sync worker validators.
 - Integration tests that:
   - Issue a token, connect to LiveStore, and confirm no network call happens during validation.
@@ -128,13 +129,13 @@ Because we have no active production sessions, we can ship this as a single PR w
 
 ## Risks & Mitigations
 
-| Risk | Impact | Mitigation |
-| --- | --- | --- |
-| Token size grows beyond header limits for users with many workspaces | Failed logins or sync connects | Store only workspace IDs + role (short strings). Log claim sizes; consider chunking or secondary fetch if someone exceeds ~4 KB. |
-| Version map out-of-sync (KV write fails) | Revocations delayed | Retry KV writes with backoff, emit Sentry errors, and fall back to forcing JWT expiration if KV is unavailable. |
-| Token issued without incremented version | Revoked users keep access | Centralize membership mutations through helpers that always bump version + write KV; add test coverage + Sentry assertions. |
-| KV read failures in sync worker | Users blocked or allowed when they shouldn’t be | Cache last known version and treat KV failure as “stale” (force refresh) while logging and alerting. |
-| Client refresh loop bugs | Users stuck refreshing | Provide explicit error codes so AuthContext can differentiate “stale version” from other failures and show actionable UI. |
+| Risk                                                                 | Impact                                          | Mitigation                                                                                                                       |
+| -------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Token size grows beyond header limits for users with many workspaces | Failed logins or sync connects                  | Store only workspace IDs + role (short strings). Log claim sizes; consider chunking or secondary fetch if someone exceeds ~4 KB. |
+| Version map out-of-sync (KV write fails)                             | Revocations delayed                             | Retry KV writes with backoff, emit Sentry errors, and fall back to forcing JWT expiration if KV is unavailable.                  |
+| Token issued without incremented version                             | Revoked users keep access                       | Centralize membership mutations through helpers that always bump version + write KV; add test coverage + Sentry assertions.      |
+| KV read failures in sync worker                                      | Users blocked or allowed when they shouldn’t be | Cache last known version and treat KV failure as “stale” (force refresh) while logging and alerting.                             |
+| Client refresh loop bugs                                             | Users stuck refreshing                          | Provide explicit error codes so AuthContext can differentiate “stale version” from other failures and show actionable UI.        |
 
 ## Deliverables
 


### PR DESCRIPTION
Fixes formatting inconsistencies across documentation files:

- Add blank lines after section headers for consistency
- Reformat markdown tables to improve readability
- Ensure consistent code block spacing

These are minimal formatting improvements with no content changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize markdown formatting across docs, reformat a risks table, and tidy a code snippet.
> 
> - **Docs**:
>   - **`docs/adrs/008-distributed-security-policy.md`**: Add spacing for readability in Consequences and follow-up sections.
>   - **`docs/plans/026-new-ui-foundation/plan.md`**: Add consistent blank lines; minor code snippet cleanup (inline assignee mapping); clarify routing/examples spacing.
>   - **`docs/plans/031-workspace-claims-in-jwt.md`**: Reformat Risks table to proper Markdown; add spacing in testing/validation section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f7afdea2190a33a25719a893d4263cbcc926c6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->