### PR TITLE
Wire Life Map room chat

### DIFF
--- a/packages/web/src/Root.tsx
+++ b/packages/web/src/Root.tsx
@@ -38,6 +38,8 @@ import { ProjectDetailPage } from './components/new/projects/ProjectDetailPage.j
 import { NewUiShell } from './components/new/layout/NewUiShell.js'
 import { LifeMap } from './components/new/life-map/LifeMap.js'
 import { LifeCategory } from './components/new/life-category/LifeCategory.js'
+import { RoomLayout } from './components/new/layout/RoomLayout.js'
+import { LIFE_MAP_ROOM } from '@work-squared/shared/rooms'
 
 const adapter = makePersistedAdapter({
   storage: { type: 'opfs' },
@@ -167,9 +169,19 @@ const ProtectedApp: React.FC = () => {
                       path={ROUTES.NEW}
                       element={
                         <ErrorBoundary>
-                          <NewUiShell>
+                          <RoomLayout room={LIFE_MAP_ROOM}>
                             <LifeMap />
-                          </NewUiShell>
+                          </RoomLayout>
+                        </ErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path={ROUTES.NEW_LIFE_MAP}
+                      element={
+                        <ErrorBoundary>
+                          <RoomLayout room={LIFE_MAP_ROOM}>
+                            <LifeMap />
+                          </RoomLayout>
                         </ErrorBoundary>
                       }
                     />

--- a/packages/web/src/components/new/layout/RoomLayout.test.tsx
+++ b/packages/web/src/components/new/layout/RoomLayout.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { RoomLayout } from './RoomLayout.js'
+import { LIFE_MAP_ROOM } from '@work-squared/shared/rooms'
+
+vi.mock('../../../constants/featureFlags.js', () => ({
+  isRoomChatEnabled: true,
+}))
+
+const mockSendMessage = vi.fn()
+const mockSetMessageText = vi.fn()
+
+vi.mock('../../../hooks/useRoomChat.js', () => ({
+  useRoomChat: () => ({
+    worker: {
+      id: 'life-map-mesa',
+      name: 'MESA',
+      roleDescription: 'Life Map Navigator',
+      defaultModel: 'gpt-4o-mini',
+      systemPrompt: '',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      roomId: 'life-map',
+      roomKind: 'life-map',
+      status: 'active',
+      isActive: true,
+      avatar: null,
+    },
+    conversation: {
+      id: 'conversation-1',
+      title: 'MESA Chat',
+      model: 'gpt-4o-mini',
+      workerId: 'life-map-mesa',
+      roomId: 'life-map',
+      roomKind: 'life-map',
+      scope: 'workspace',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      processingState: 'idle',
+    },
+    messages: [],
+    isProcessing: false,
+    isProvisioning: false,
+    messageText: '',
+    setMessageText: mockSetMessageText,
+    sendMessage: mockSendMessage,
+  }),
+}))
+
+describe('RoomLayout', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    mockSendMessage.mockReset()
+    mockSetMessageText.mockReset()
+  })
+
+  it('renders children and toggles chat panel', () => {
+    render(
+      <RoomLayout room={LIFE_MAP_ROOM}>
+        <div>Life Map Content</div>
+      </RoomLayout>
+    )
+
+    expect(screen.getByText('Life Map Content')).toBeInTheDocument()
+
+    const toggle = screen.getByRole('button', { name: /show chat/i })
+    fireEvent.click(toggle)
+
+    expect(screen.getByRole('button', { name: /hide chat/i })).toBeInTheDocument()
+    expect(screen.getByText('Send')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add RoomLayout wrapper that instantiates the room chat hooks/components and persists the chat toggle state per room
- wire the /new and /new/life-map routes to use RoomLayout with the MESA definition so we can start chatting from the Life Map once the flag is enabled
- cover the new layout with a simple RTL test and keep RoomChatPanel tests in sync with the slimmer header

## Testing
- pnpm lint-all
- pnpm test
- CI=true pnpm test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `RoomLayout` that integrates room chat (with per-room persisted toggle) and apply it to `/new` and `/new/life-map` Life Map routes, with tests.
> 
> - **Web**:
>   - **Layout**: Add `components/new/layout/RoomLayout.tsx` that wraps `NewUiShell`, integrates room chat via `useRoomChat`, `RoomChatToggle`, `RoomChatPanel`, persists open state in `localStorage`, and honors `isRoomChatEnabled`.
>   - **Routing**: Update `packages/web/src/Root.tsx` to wrap `LifeMap` under `ROUTES.NEW` and `ROUTES.NEW_LIFE_MAP` with `RoomLayout` using `LIFE_MAP_ROOM`.
>   - **Tests**: Add `components/new/layout/RoomLayout.test.tsx` to verify child rendering and chat panel toggle/send UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29b1da8d2dc6fe5f2f959e5c079d1041e5181c1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->