### PR TITLE
Add new UI projects foundation pages

### DIFF
--- a/packages/web/src/Root.tsx
+++ b/packages/web/src/Root.tsx
@@ -36,6 +36,7 @@ import { schema } from '@work-squared/shared/schema'
 import { ROUTES } from './constants/routes.js'
 import { ProjectDetailPage } from './components/new/projects/ProjectDetailPage.js'
 import { NewUiShell } from './components/new/layout/NewUiShell.js'
+import { ProjectsListPage } from './components/new/projects/ProjectsListPage.js'
 import { LifeMap } from './components/new/life-map/LifeMap.js'
 import { LifeCategory } from './components/new/life-category/LifeCategory.js'
 import { RoomLayout } from './components/new/layout/RoomLayout.js'
@@ -281,6 +282,16 @@ const ProtectedApp: React.FC = () => {
                         <ErrorBoundary>
                           <NewUiShell>
                             <ProjectDetailPage />
+                          </NewUiShell>
+                        </ErrorBoundary>
+                      }
+                    />
+                    <Route
+                      path={ROUTES.NEW_PROJECTS}
+                      element={
+                        <ErrorBoundary>
+                          <NewUiShell>
+                            <ProjectsListPage />
                           </NewUiShell>
                         </ErrorBoundary>
                       }

--- a/packages/web/src/components/new/README.md
+++ b/packages/web/src/components/new/README.md
@@ -4,7 +4,7 @@ This directory contains the in-progress reimplementation of the Work Squared int
 
 ## Structure
 
-- `projects/` – Foundations for the new Projects list and Project detail experiences.
+- `projects/` – Pages and stories for the new Projects list and Project detail experiences.
 - `layout/` – Lightweight shells used to keep new surfaces independent from the legacy navbar/chat chrome.
 
 ## Guidelines
@@ -14,5 +14,14 @@ This directory contains the in-progress reimplementation of the Work Squared int
 - Prefer small, focused components that can evolve into the future design system.
 - Continue to preserve the `storeId` query parameter via `preserveStoreIdInUrl` when linking between routes.
 - Route-level shells (e.g., `NewUiShell`) should not pull in legacy layout primitives; they are responsible for providing only the minimal spacing/background baseline the new UI needs.
+
+## Projects surfaces
+
+- `ProjectsListPage.tsx` – `/new/projects` route showing a simple list of projects.
+- `ProjectsListPage.stories.tsx` – Default, empty, and single-project stories seeded with LiveStore events.
+- `ProjectDetailPage.tsx` – `/new/projects/:projectId` route listing project details and tasks.
+- `ProjectDetailPage.stories.tsx` – Default, empty, single-task, and many-task stories seeded with LiveStore events.
+
+Refer back to `docs/plans/026-new-ui-foundation/plan.md` for the expected Storybook hierarchy and data scenarios.
 
 These guidelines will evolve as additional plans land; keep this README up to date as new directories are added.

--- a/packages/web/src/components/new/projects/ProjectDetailPage.stories.tsx
+++ b/packages/web/src/components/new/projects/ProjectDetailPage.stories.tsx
@@ -7,6 +7,7 @@ import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 import { Store } from '@livestore/livestore'
 import { schema, events } from '@work-squared/shared/schema'
 import { ProjectDetailPage } from './ProjectDetailPage.js'
+import { NewUiShell } from '../layout/NewUiShell.js'
 
 type TaskSeed = {
   id: string
@@ -33,9 +34,11 @@ const withProjectProviders =
           boot?.(store)
         }}
       >
-        <Routes>
-          <Route path='/new/projects/:projectId' element={<Story />} />
-        </Routes>
+        <NewUiShell>
+          <Routes>
+            <Route path='/new/projects/:projectId' element={<Story />} />
+          </Routes>
+        </NewUiShell>
       </LiveStoreProvider>
     )
   }
@@ -214,14 +217,17 @@ export const Default: Story = {
 
 export const EmptyState: Story = {
   decorators: [withProjectProviders('project-empty', emptyProjectSetup)],
+  name: 'Empty State',
 }
 
 export const SingleTask: Story = {
   decorators: [withProjectProviders('project-single-task', singleTaskSetup)],
+  name: 'Single Task',
 }
 
 export const ManyTasks: Story = {
   decorators: [withProjectProviders('project-many', manyTasksSetup)],
+  name: 'Many Tasks',
   parameters: {
     docs: {
       description: {

--- a/packages/web/src/components/new/projects/ProjectDetailPage.tsx
+++ b/packages/web/src/components/new/projects/ProjectDetailPage.tsx
@@ -8,15 +8,7 @@ import {
   getTaskComments$,
 } from '@work-squared/shared/queries'
 import type { Project, Task, User } from '@work-squared/shared/schema'
-import {
-  ARCHETYPE_LABELS,
-  STAGE_LABELS,
-  type PlanningAttributes,
-  type ProjectCategory,
-  PROJECT_CATEGORIES,
-  getCategoryInfo,
-} from '@work-squared/shared'
-import { generateRoute } from '../../../constants/routes.js'
+import { ROUTES } from '../../../constants/routes.js'
 import { preserveStoreIdInUrl } from '../../../utils/navigation.js'
 
 const parseAssigneeIds = (raw: string | null | undefined): string[] => {
@@ -33,30 +25,26 @@ type UsersById = Map<string, User>
 
 const TaskListItem: React.FC<{ task: Task; usersById: UsersById }> = ({ task, usersById }) => {
   const comments = useQuery(getTaskComments$(task.id)) ?? []
-  const assigneeIds = parseAssigneeIds(task.assigneeIds)
-  const assignees = assigneeIds
-    .map(id => usersById.get(id))
-    .filter((user): user is User => Boolean(user))
-  const assigneeNames = assignees.map(user => user.name || user.email || user.id)
+  const assigneeNames = useMemo(() => {
+    const assignees = parseAssigneeIds(task.assigneeIds)
+      .map(id => usersById.get(id))
+      .filter((user): user is User => Boolean(user))
+    return assignees.map(user => user.name || user.email || user.id).join(', ')
+  }, [task.assigneeIds, usersById])
   const hasDescription = Boolean(task.description && task.description.trim().length > 0)
   const hasComments = comments.length > 0
 
   return (
-    <li className='mb-2'>
+    <li className='new-ui-list-item'>
       <div>
         <strong className='font-semibold'>{task.title || 'Untitled task'}</strong>
         <span> [{task.status}]</span>
       </div>
       <div>
-        <span>Assignees: {assigneeNames.length > 0 ? assigneeNames.join(', ') : 'Unassigned'}</span>
+        <span>Assignees: {assigneeNames || 'Unassigned'}</span>
         {hasDescription && <span> 📝</span>}
-        {hasComments && <span> 💬 ({comments.length})</span>}
+        {hasComments && <span> 💬</span>}
       </div>
-      {task.description && (
-        <div>
-          <small>{task.description}</small>
-        </div>
-      )}
     </li>
   )
 }
@@ -64,187 +52,54 @@ const TaskListItem: React.FC<{ task: Task; usersById: UsersById }> = ({ task, us
 export const ProjectDetailPage: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>()
   const resolvedProjectId = projectId ?? '__invalid__'
-  const projectRows = useQuery(getProjectById$(resolvedProjectId)) ?? []
+  const projectRows = useQuery(getProjectById$(resolvedProjectId))
+  const project = (projectRows?.[0] ?? undefined) as Project | undefined
   const tasks = useQuery(getProjectTasks$(resolvedProjectId)) ?? []
   const users = useQuery(getUsers$) ?? []
   const usersById = useMemo(() => new Map(users.map(user => [user.id, user])), [users])
-  const project = (projectRows[0] ?? undefined) as Project | undefined
 
-  // Parse project attributes
-  const attributes = useMemo(() => {
-    if (!project?.attributes) return null
-    try {
-      const parsed =
-        typeof project.attributes === 'string'
-          ? JSON.parse(project.attributes)
-          : (project.attributes as PlanningAttributes)
-      return parsed as PlanningAttributes
-    } catch {
-      return null
-    }
-  }, [project?.attributes])
-
-  const projectCategory = useMemo<ProjectCategory | null>(() => {
-    const category = project?.category
-    if (!category) return null
-    return PROJECT_CATEGORIES.some(({ value }) => value === category)
-      ? (category as ProjectCategory)
-      : null
-  }, [project?.category])
-
-  // Determine back link and label based on project category
-  const backLink = useMemo(() => {
-    if (projectCategory) {
-      return preserveStoreIdInUrl(generateRoute.newCategory(projectCategory))
-    }
-    return preserveStoreIdInUrl('/new')
-  }, [projectCategory])
-
-  const backLabel = useMemo(() => {
-    if (projectCategory) {
-      const categoryInfo = getCategoryInfo(projectCategory)
-      return categoryInfo ? `← Back to ${categoryInfo.name}` : `← Back to ${projectCategory}`
-    }
-    return '← Back to Life Map'
-  }, [projectCategory])
-
-  // Format date helper
-  const formatDate = (timestamp?: number) => {
-    if (!timestamp) return null
-    return new Date(timestamp).toLocaleDateString()
+  if (!projectId) {
+    return (
+      <div className='space-y-4'>
+        <Link to={preserveStoreIdInUrl(ROUTES.NEW_PROJECTS)}>← Back to projects</Link>
+        <p>Invalid project ID</p>
+      </div>
+    )
   }
 
-  // Format duration helper
-  const formatDuration = (hours?: number) => {
-    if (!hours) return null
-    if (hours < 1) return `${Math.round(hours * 60)} minutes`
-    if (hours < 24) return `${hours.toFixed(1)} hours`
-    const days = Math.floor(hours / 24)
-    const remainingHours = hours % 24
-    if (remainingHours === 0) return `${days} day${days !== 1 ? 's' : ''}`
-    return `${days} day${days !== 1 ? 's' : ''}, ${remainingHours.toFixed(1)} hours`
+  if (!project) {
+    return (
+      <div className='space-y-4'>
+        <Link to={preserveStoreIdInUrl(ROUTES.NEW_PROJECTS)}>← Back to projects</Link>
+        <div>
+          <h1 className='new-ui-heading'>Project not found</h1>
+          <p>The requested project ({projectId}) does not exist.</p>
+        </div>
+      </div>
+    )
   }
 
   return (
-    <div>
-      <Link to={backLink}>{backLabel}</Link>
+    <div className='space-y-6'>
+      <Link to={preserveStoreIdInUrl(ROUTES.NEW_PROJECTS)}>← Back to projects</Link>
 
-      {!projectId ? (
-        <p>Invalid project ID</p>
-      ) : !project ? (
-        <div>
-          <h1>Project not found</h1>
-          <p>The requested project ({projectId}) does not exist.</p>
-        </div>
-      ) : (
-        <div>
-          <header>
-            <h1 className='text-2xl font-bold'>{project.name || 'Untitled project'}</h1>
-            {project.description && <p>{project.description}</p>}
-          </header>
+      <header className='space-y-2'>
+        <h1 className='new-ui-heading-lg'>{project.name || 'Untitled project'}</h1>
+        {project.description && <p>{project.description}</p>}
+      </header>
 
-          {attributes && (
-            <section className='mt-6'>
-              <h2 className='text-lg font-semibold mb-4'>Project Attributes</h2>
-              <dl className='space-y-2'>
-                {attributes.status && (
-                  <div>
-                    <dt className='font-medium inline'>Status:</dt>
-                    <dd className='inline ml-2 capitalize'>{attributes.status}</dd>
-                  </div>
-                )}
-                {attributes.planningStage && (
-                  <div>
-                    <dt className='font-medium inline'>Planning Stage:</dt>
-                    <dd className='inline ml-2'>
-                      {STAGE_LABELS[attributes.planningStage]} (Stage {attributes.planningStage})
-                    </dd>
-                  </div>
-                )}
-                {attributes.archetype && (
-                  <div>
-                    <dt className='font-medium inline'>Archetype:</dt>
-                    <dd className='inline ml-2'>{ARCHETYPE_LABELS[attributes.archetype]}</dd>
-                  </div>
-                )}
-                {attributes.objectives && (
-                  <div>
-                    <dt className='font-medium block mb-1'>Objectives:</dt>
-                    <dd className='ml-4'>{attributes.objectives}</dd>
-                  </div>
-                )}
-                {attributes.deadline && (
-                  <div>
-                    <dt className='font-medium inline'>Deadline:</dt>
-                    <dd className='inline ml-2'>{formatDate(attributes.deadline)}</dd>
-                  </div>
-                )}
-                {attributes.estimatedDuration && (
-                  <div>
-                    <dt className='font-medium inline'>Estimated Duration:</dt>
-                    <dd className='inline ml-2'>{formatDuration(attributes.estimatedDuration)}</dd>
-                  </div>
-                )}
-                {attributes.urgency && (
-                  <div>
-                    <dt className='font-medium inline'>Urgency:</dt>
-                    <dd className='inline ml-2 capitalize'>{attributes.urgency}</dd>
-                  </div>
-                )}
-                {attributes.importance && (
-                  <div>
-                    <dt className='font-medium inline'>Importance:</dt>
-                    <dd className='inline ml-2 capitalize'>{attributes.importance}</dd>
-                  </div>
-                )}
-                {attributes.complexity && (
-                  <div>
-                    <dt className='font-medium inline'>Complexity:</dt>
-                    <dd className='inline ml-2 capitalize'>{attributes.complexity}</dd>
-                  </div>
-                )}
-                {attributes.scale && (
-                  <div>
-                    <dt className='font-medium inline'>Scale:</dt>
-                    <dd className='inline ml-2 capitalize'>{attributes.scale}</dd>
-                  </div>
-                )}
-                {attributes.priority !== undefined && (
-                  <div>
-                    <dt className='font-medium inline'>Priority:</dt>
-                    <dd className='inline ml-2'>{attributes.priority}</dd>
-                  </div>
-                )}
-                {attributes.activatedAt && (
-                  <div>
-                    <dt className='font-medium inline'>Activated At:</dt>
-                    <dd className='inline ml-2'>{formatDate(attributes.activatedAt)}</dd>
-                  </div>
-                )}
-                {attributes.lastActivityAt && (
-                  <div>
-                    <dt className='font-medium inline'>Last Activity:</dt>
-                    <dd className='inline ml-2'>{formatDate(attributes.lastActivityAt)}</dd>
-                  </div>
-                )}
-              </dl>
-            </section>
-          )}
-
-          <section className='mt-6'>
-            <h2 className='text-lg font-semibold mb-4'>Tasks</h2>
-            {tasks.length === 0 ? (
-              <p>No tasks in this project</p>
-            ) : (
-              <ul>
-                {tasks.map(task => (
-                  <TaskListItem key={task.id} task={task} usersById={usersById} />
-                ))}
-              </ul>
-            )}
-          </section>
-        </div>
-      )}
+      <section className='space-y-3'>
+        <h2 className='new-ui-subheading'>Tasks</h2>
+        {tasks.length === 0 ? (
+          <p>No tasks in this project</p>
+        ) : (
+          <ul className='new-ui-list'>
+            {tasks.map(task => (
+              <TaskListItem key={task.id} task={task} usersById={usersById} />
+            ))}
+          </ul>
+        )}
+      </section>
     </div>
   )
 }

--- a/packages/web/src/components/new/projects/ProjectsListPage.stories.tsx
+++ b/packages/web/src/components/new/projects/ProjectsListPage.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
+import { LiveStoreProvider } from '@livestore/react'
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
+import { Store } from '@livestore/livestore'
+import { schema, events } from '@work-squared/shared/schema'
+import { ProjectsListPage } from './ProjectsListPage.js'
+import { NewUiShell } from '../layout/NewUiShell.js'
+
+const withProjectsProvider =
+  (boot?: (store: Store) => void) =>
+  (Story: React.ComponentType): React.ReactElement => {
+    if (typeof window !== 'undefined') {
+      window.history.replaceState({}, '', '/new/projects')
+    }
+
+    return (
+      <LiveStoreProvider
+        schema={schema}
+        adapter={makeInMemoryAdapter()}
+        batchUpdates={batchUpdates}
+        boot={store => {
+          boot?.(store)
+        }}
+      >
+        <NewUiShell>
+          <Story />
+        </NewUiShell>
+      </LiveStoreProvider>
+    )
+  }
+
+const meta: Meta<typeof ProjectsListPage> = {
+  title: 'New UI/Projects/ProjectsListPage',
+  component: ProjectsListPage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'Text-only list of projects for the new UI foundation.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const seedProjects = (
+  store: Store,
+  projects: { id: string; name: string; description?: string }[]
+) => {
+  const baseDate = new Date('2024-01-01T00:00:00Z').getTime()
+  projects.forEach((project, index) => {
+    store.commit(
+      events.projectCreated({
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        createdAt: new Date(baseDate + index * 1000),
+        actorId: 'storybook',
+      })
+    )
+  })
+}
+
+const defaultSetup = (store: Store) => {
+  seedProjects(store, [
+    { id: 'project-alpha', name: 'Project Alpha', description: 'Initial foundation work.' },
+    { id: 'project-beta', name: 'Project Beta', description: 'Follow-up tasks.' },
+    { id: 'project-gamma', name: 'Project Gamma', description: 'Exploratory research.' },
+    { id: 'project-delta', name: 'Project Delta', description: 'Infrastructure planning.' },
+  ])
+}
+
+const emptySetup = (_store: Store) => {}
+
+const singleProjectSetup = (store: Store) => {
+  seedProjects(store, [
+    { id: 'solo-project', name: 'Solo Project', description: 'Only one project here.' },
+  ])
+}
+
+export const Default: Story = {
+  decorators: [withProjectsProvider(defaultSetup)],
+}
+
+export const EmptyState: Story = {
+  decorators: [withProjectsProvider(emptySetup)],
+  name: 'Empty State',
+}
+
+export const SingleProject: Story = {
+  decorators: [withProjectsProvider(singleProjectSetup)],
+  name: 'Single Project',
+}

--- a/packages/web/src/components/new/projects/ProjectsListPage.tsx
+++ b/packages/web/src/components/new/projects/ProjectsListPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { useQuery } from '@livestore/react'
+import { getProjects$ } from '@work-squared/shared/queries'
+import { generateRoute } from '../../../constants/routes.js'
+import { preserveStoreIdInUrl } from '../../../utils/navigation.js'
+
+export const ProjectsListPage: React.FC = () => {
+  const projects = useQuery(getProjects$) ?? []
+
+  return (
+    <div className='space-y-4'>
+      <h1 className='new-ui-heading-lg'>Projects</h1>
+      {projects.length === 0 ? (
+        <p>No projects yet</p>
+      ) : (
+        <ul className='new-ui-list'>
+          {projects.map(project => (
+            <li key={project.id} className='new-ui-list-item'>
+              <Link to={preserveStoreIdInUrl(generateRoute.newProject(project.id))}>
+                {project.name || 'Untitled project'}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add /new/projects routing with a simple ProjectsListPage
- simplify the new ProjectDetailPage to show project info and tasks per the foundation plan
- document new UI project surfaces and provide Storybook coverage for both pages

## Testing
- pnpm lint-all
- pnpm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `/new/projects` list view and streamlines the project detail page to show basic info and tasks, with updated routes, stories, and docs.
> 
> - **New UI – Projects**:
>   - **Routing**: Add `ROUTES.NEW_PROJECTS` route in `Root.tsx` rendering `ProjectsListPage` in `NewUiShell`.
>   - **Projects List**: New `components/new/projects/ProjectsListPage.tsx` showing projects via `getProjects$` with links to `newProject`.
>   - **Project Detail**: Simplify `ProjectDetailPage.tsx` to header + tasks list; remove planning/category logic and attribute rendering; add not-found/invalid states; minor styling tweaks and assignee names memoization.
>   - **Storybook**: Add `ProjectsListPage.stories.tsx` (default/empty/single); update `ProjectDetailPage.stories.tsx` to wrap with `NewUiShell` and name variants.
>   - **Docs**: Update `components/new/README.md` documenting projects surfaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fc4ffae521af00d2d34f4fbf2e519b10283302e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->