### PR TITLE
Update category card labels in Life Map

### DIFF
--- a/packages/web/src/components/new/life-map/CategoryCard.tsx
+++ b/packages/web/src/components/new/life-map/CategoryCard.tsx
@@ -128,7 +128,7 @@ export const CategoryCard: React.FC<CategoryCardProps> = ({
               style={{ textDecoration: 'none' }}
               onClick={e => e.stopPropagation()}
             >
-              PLANNING ({planningCount})
+              DRAFTING ({planningCount})
             </Link>
           )}
           {backlogCount > 0 && (
@@ -138,7 +138,7 @@ export const CategoryCard: React.FC<CategoryCardProps> = ({
               style={{ textDecoration: 'none' }}
               onClick={e => e.stopPropagation()}
             >
-              BACKLOG ({backlogCount})
+              SORTING ({backlogCount})
             </Link>
           )}
         </div>


### PR DESCRIPTION
Change "Planning" to "Drafting" and "Backlog" to "Sorting" for consistency with the UI terminology.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename CategoryCard link labels: PLANNING -> DRAFTING and BACKLOG -> SORTING.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 419b4aa4910248ec10879c2814f643d80dea4d45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->