### PR TITLE
Phase 5: Update documentation and scripts for LifeBuild rebrand

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Work Squared Documentation
+# LifeBuild Documentation
 
-This directory contains the technical documentation for Work Squared, organized by purpose and chronological development.
+This directory contains the technical documentation for LifeBuild, organized by purpose and chronological development.
 
 ## Architecture
 

--- a/packages/web/src/components/new/README.md
+++ b/packages/web/src/components/new/README.md
@@ -1,6 +1,6 @@
 # New UI Components
 
-This directory contains the in-progress reimplementation of the Work Squared interface. Pages and components that live here are intentionally minimal – their primary goal is to establish routing, data-fetching patterns, and baseline rendering for the new `/new` route hierarchy.
+This directory contains the in-progress reimplementation of the LifeBuild interface. Pages and components that live here are intentionally minimal – their primary goal is to establish routing, data-fetching patterns, and baseline rendering for the new `/new` route hierarchy.
 
 ## Structure
 

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Claude Code on the Web setup script for Work Squared
+# Claude Code on the Web setup script for LifeBuild
 # This script runs as a SessionStart hook to configure the environment
 
 set -e  # Exit on any error
 
-echo "🚀 Setting up Work Squared environment for Claude Code on the web..."
+echo "🚀 Setting up LifeBuild environment for Claude Code on the web..."
 
 # Only run in remote (web) environments
 if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
@@ -229,8 +229,8 @@ pnpm exec playwright install
 # Persist environment variables for subsequent bash commands
 # This makes NODE_ENV and branch info available to Claude Code
 if [ -n "$CLAUDE_ENV_FILE" ]; then
-    echo "export WORK_SQUARED_BRANCH=${BRANCH_NAME}" >> "$CLAUDE_ENV_FILE"
-    echo "✅ Persisted WORK_SQUARED_BRANCH environment variable"
+    echo "export LIFEBUILD_BRANCH=${BRANCH_NAME}" >> "$CLAUDE_ENV_FILE"
+    echo "✅ Persisted LIFEBUILD_BRANCH environment variable"
 fi
 
 echo "✨ Environment setup complete!"

--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Conductor setup script for Work Squared
+# Conductor setup script for LifeBuild
 # This script sets up a new worktree environment with proper configuration
 
 set -e  # Exit on any error
 
-echo "🚀 Setting up Work Squared worktree environment..."
+echo "🚀 Setting up LifeBuild worktree environment..."
 
 # Check if we're in a worktree (CONDUCTOR_ROOT_PATH should be set)
 if [ -z "$CONDUCTOR_ROOT_PATH" ]; then


### PR DESCRIPTION
## Summary

- Update `docs/README.md` with LifeBuild branding (title and description)
- Update `packages/web/src/components/new/README.md` to reference LifeBuild interface
- Update `scripts/claude-web-setup.sh` with LifeBuild branding and rename `WORK_SQUARED_BRANCH` env var to `LIFEBUILD_BRANCH`
- Update `scripts/conductor-setup.sh` with LifeBuild branding

This completes the documentation portion of Phase 5 from the rebrand plan. Historical planning docs under `docs/plans/` and `docs/adrs/` are intentionally deferred for a separate PR per the plan.

## Test plan

- [x] Run `pnpm lint-all` - passes
- [x] Run `pnpm test` - all 564 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rebrands docs and setup scripts to LifeBuild and renames the persisted branch env var to LIFEBUILD_BRANCH.
> 
> - **Documentation**:
>   - Update branding from `Work Squared` to `LifeBuild` in `docs/README.md` and `packages/web/src/components/new/README.md`.
> - **Scripts**:
>   - Update branding strings in `scripts/claude-web-setup.sh` and `scripts/conductor-setup.sh`.
>   - Rename persisted env var from `WORK_SQUARED_BRANCH` to `LIFEBUILD_BRANCH` in `scripts/claude-web-setup.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e61b1471172adfececbbabe67150473a55eb330. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->