### PR TITLE
Remove legacy AUTH_TOKEN in favor of SERVER_BYPASS_TOKEN

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -3,7 +3,6 @@
 STORE_IDS=workspace-123,workspace-456,workspace-789
 
 # Default Store Connection Settings
-AUTH_TOKEN=insecure-token-change-me
 LIVESTORE_SYNC_URL=ws://localhost:8787
 STORE_DATA_PATH=./data
 
@@ -15,7 +14,6 @@ STORE_MAX_RECONNECT_ATTEMPTS=3
 # Store-specific configuration (optional)
 # Format: STORE_<STORE_ID>_<SETTING>
 # Example for workspace-123:
-# STORE_WORKSPACE_123_AUTH_TOKEN=specific-token-for-workspace-123
 # STORE_WORKSPACE_123_SYNC_URL=ws://custom-url:8787
 # STORE_WORKSPACE_123_DATA_PATH=./data/custom-path
 # STORE_WORKSPACE_123_DEVTOOLS_URL=http://localhost:4301

--- a/packages/server/.env.production
+++ b/packages/server/.env.production
@@ -3,7 +3,6 @@
 
 # LiveStore Configuration
 STORE_ID=lifebuild-production
-AUTH_TOKEN=RENDER_WILL_GENERATE_THIS
 LIVESTORE_SYNC_URL=wss://your-worker.your-domain.workers.dev
 
 # Server Configuration

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -55,8 +55,10 @@ Create a `.env` file with the following variables:
 ```env
 # LiveStore Configuration
 STORE_ID=lifebuild-default           # Unique identifier for this workspace
-AUTH_TOKEN=your-secure-token           # Auth token for sync (change in production)
 LIVESTORE_SYNC_URL=ws://localhost:8787  # WebSocket URL to Cloudflare Worker
+
+# Server Bypass Token (required for production)
+SERVER_BYPASS_TOKEN=dev-server-bypass-token  # Must match worker's SERVER_BYPASS_TOKEN
 
 # Server Configuration
 PORT=3003                              # HTTP health check port
@@ -67,13 +69,13 @@ NODE_ENV=development
 
 ### Environment Variables
 
-| Variable             | Description                   | Default                    | Required |
-| -------------------- | ----------------------------- | -------------------------- | -------- |
-| `STORE_ID`           | Unique workspace identifier   | `lifebuild-default`        | No       |
-| `AUTH_TOKEN`         | Authentication token for sync | `insecure-token-change-me` | No       |
-| `LIVESTORE_SYNC_URL` | WebSocket connection URL      | `ws://localhost:8787`      | No       |
-| `PORT`               | HTTP server port              | `3003`                     | No       |
-| `NODE_ENV`           | Node environment              | `development`              | No       |
+| Variable              | Description                  | Default               | Required   |
+| --------------------- | ---------------------------- | --------------------- | ---------- |
+| `STORE_ID`            | Unique workspace identifier  | `lifebuild-default`   | No         |
+| `LIVESTORE_SYNC_URL`  | WebSocket connection URL     | `ws://localhost:8787` | No         |
+| `SERVER_BYPASS_TOKEN` | Token for server-worker auth | -                     | Production |
+| `PORT`                | HTTP server port             | `3003`                | No         |
+| `NODE_ENV`            | Node environment             | `development`         | No         |
 
 ## Development
 
@@ -182,7 +184,7 @@ Coming soon.
 
 For production deployments:
 
-1. **Generate secure AUTH_TOKEN**: Use a strong random string
+1. **Set SERVER_BYPASS_TOKEN**: Use a strong random string that matches the worker's token
 2. **Configure STORE_ID**: Set to your workspace identifier
 3. **Set LIVESTORE_SYNC_URL**: Point to your Cloudflare Worker
 4. **Ensure data persistence**: Mount `./data` directory

--- a/packages/server/render.yaml
+++ b/packages/server/render.yaml
@@ -15,8 +15,6 @@ services:
           type: web
           name: lifebuild-server
           property: port
-      - key: AUTH_TOKEN
-        generateValue: true
       - key: LIVESTORE_SYNC_URL
         value: wss://sync.lifebuild.me
       - key: SERVER_BYPASS_TOKEN

--- a/packages/server/tests/config/stores.test.ts
+++ b/packages/server/tests/config/stores.test.ts
@@ -105,10 +105,10 @@ describe('Store Configuration', () => {
 
   describe('getStoreSpecificEnvVar', () => {
     it('should get store-specific environment variable', () => {
-      process.env.STORE_WORKSPACE_123_AUTH_TOKEN = 'custom-token'
+      process.env.STORE_WORKSPACE_123_SYNC_URL = 'ws://custom:8787'
 
-      const value = getStoreSpecificEnvVar('workspace-123', 'AUTH_TOKEN')
-      expect(value).toBe('custom-token')
+      const value = getStoreSpecificEnvVar('workspace-123', 'SYNC_URL')
+      expect(value).toBe('ws://custom:8787')
     })
 
     it('should handle store IDs with hyphens', () => {
@@ -126,8 +126,8 @@ describe('Store Configuration', () => {
 
   describe('hasStoreSpecificConfig', () => {
     it('should return true if store has specific config', () => {
-      process.env.STORE_WORKSPACE_123_AUTH_TOKEN = 'custom-token'
       process.env.STORE_WORKSPACE_123_SYNC_URL = 'ws://custom:8787'
+      process.env.STORE_WORKSPACE_123_DATA_PATH = './custom-path'
 
       expect(hasStoreSpecificConfig('workspace-123')).toBe(true)
     })

--- a/packages/server/tests/factories/store-factory.test.ts
+++ b/packages/server/tests/factories/store-factory.test.ts
@@ -65,7 +65,6 @@ describe('Store Factory', () => {
       const config = getStoreConfig('test-store')
 
       expect(config.storeId).toBe('test-store')
-      expect(config.authToken).toBe('token-test-store')
       expect(config.syncUrl).toBe('ws://localhost:8787')
       expect(config.dataPath).toBe('./data')
       expect(config.connectionTimeout).toBe(30000)
@@ -74,7 +73,6 @@ describe('Store Factory', () => {
     })
 
     it('should use global environment variables', () => {
-      process.env.AUTH_TOKEN = 'global-token'
       process.env.LIVESTORE_SYNC_URL = 'ws://global:8787'
       process.env.STORE_DATA_PATH = './global-data'
       process.env.STORE_CONNECTION_TIMEOUT = '60000'
@@ -82,7 +80,6 @@ describe('Store Factory', () => {
 
       const config = getStoreConfig('test-store')
 
-      expect(config.authToken).toBe('global-token')
       expect(config.syncUrl).toBe('ws://global:8787')
       expect(config.dataPath).toBe('./global-data')
       expect(config.connectionTimeout).toBe(60000)
@@ -90,26 +87,15 @@ describe('Store Factory', () => {
     })
 
     it('should prioritize store-specific environment variables', () => {
-      process.env.AUTH_TOKEN = 'global-token'
-      process.env.STORE_TEST_STORE_AUTH_TOKEN = 'specific-token'
       process.env.STORE_TEST_STORE_SYNC_URL = 'ws://specific:8787'
       process.env.STORE_TEST_STORE_DATA_PATH = './specific-data'
       process.env.STORE_TEST_STORE_DEVTOOLS_URL = 'http://localhost:4500'
 
       const config = getStoreConfig('test-store')
 
-      expect(config.authToken).toBe('specific-token')
       expect(config.syncUrl).toBe('ws://specific:8787')
       expect(config.dataPath).toBe('./specific-data')
       expect(config.devtoolsUrl).toBe('http://localhost:4500')
-    })
-
-    it('should handle store IDs with hyphens in env vars', () => {
-      process.env.STORE_MY_SPECIAL_STORE_AUTH_TOKEN = 'special-token'
-
-      const config = getStoreConfig('my-special-store')
-
-      expect(config.authToken).toBe('special-token')
     })
 
     it('should support store-specific devtools URL override', () => {
@@ -156,19 +142,17 @@ describe('Store Factory', () => {
         const config = factory.getConfig('test-store')
 
         expect(config.storeId).toBe('test-store')
-        expect(config.authToken).toBe('token-test-store')
+        expect(config.syncUrl).toBe('ws://localhost:8787')
       })
 
       it('should merge with default config', () => {
         factory = new StoreFactory({
-          authToken: 'factory-default-token',
           connectionTimeout: 45000,
         })
 
         const config = factory.getConfig('test-store')
 
         expect(config.storeId).toBe('test-store')
-        expect(config.authToken).toBe('factory-default-token')
         expect(config.connectionTimeout).toBe(45000)
         expect(config.syncUrl).toBe('ws://localhost:8787')
       })


### PR DESCRIPTION
## Summary

- Removes legacy `AUTH_TOKEN` environment variable and consolidates on `SERVER_BYPASS_TOKEN` for server-worker authentication
- Simplifies authentication configuration to reduce confusion
- Updates all affected code, tests, and documentation

## Changes

### Code
- Removed `authToken` from `StoreConfig` interface
- Updated `getStoreConfig()` to no longer set `authToken`
- Simplified `getSyncPayload()` to use `SERVER_BYPASS_TOKEN` for both production and development

### Configuration
- Removed `AUTH_TOKEN` from `.env.example`, `.env.production`, and `render.yaml`
- Updated store-specific env var examples to remove `AUTH_TOKEN` references

### Tests
- Updated `store-factory.test.ts` to remove `authToken` assertions
- Updated `stores.test.ts` to use `SYNC_URL` instead of `AUTH_TOKEN` in examples

### Documentation
- Updated `README.md` with `SERVER_BYPASS_TOKEN` documentation

## Test plan

- [x] `pnpm lint-all` passes
- [x] `pnpm test` passes  
- [x] `CI=true pnpm test:e2e` passes

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces all AUTH_TOKEN usage with SERVER_BYPASS_TOKEN and updates code, configs, tests, and docs accordingly.
> 
> - **Server Auth**:
>   - Remove `authToken` from `StoreConfig` and all related env handling.
>   - `getSyncPayload()` now always uses `SERVER_BYPASS_TOKEN`; in dev without it, proceeds unauthenticated; production requires it.
> - **Config**:
>   - Drop `AUTH_TOKEN` from `.env.example`, `.env.production`, and `render.yaml` (removed generated var); retain `SERVER_BYPASS_TOKEN`.
>   - Update store-specific env examples to use `SYNC_URL`/`DATA_PATH`/`DEVTOOLS_URL` only.
> - **Code**:
>   - `getStoreConfig()` no longer reads or sets `AUTH_TOKEN`; keeps per-store overrides for `SYNC_URL`, `DATA_PATH`, `DEVTOOLS_URL`.
> - **Tests**:
>   - Remove `authToken` expectations; switch examples to `SYNC_URL` and related vars in `stores.test.ts` and `store-factory.test.ts`.
> - **Docs**:
>   - README: document `SERVER_BYPASS_TOKEN`, remove `AUTH_TOKEN`, update env table and deployment steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b0bfe36c6ac16b094858c7d0e91473f419bc22c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->