### PR TITLE
Fix drafting room stage UI issues

### DIFF
--- a/packages/web/e2e/new-ui-workflow.spec.ts
+++ b/packages/web/e2e/new-ui-workflow.spec.ts
@@ -30,7 +30,7 @@ test.describe('New UI Workflow', () => {
     const taskNames = ['First test task', 'Second test task', 'Third test task']
 
     // =====================
-    // STAGE 1: Identifying
+    // STAGE 1: Identify
     // =====================
 
     // Navigate to create new project
@@ -38,7 +38,7 @@ test.describe('New UI Workflow', () => {
     await waitForLiveStoreReady(page)
 
     // Wait for Stage 1 form to load
-    await expect(page.getByText('Stage 1: Identifying')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 1: Identify')).toBeVisible({ timeout: 10000 })
 
     // Fill in project title
     const titleInput = page.locator('input[placeholder*="project called"]')
@@ -63,11 +63,11 @@ test.describe('New UI Workflow', () => {
     await continueToStage2Button.click()
 
     // =====================
-    // STAGE 2: Scoping
+    // STAGE 2: Scope
     // =====================
 
     // Wait for Stage 2 form to load
-    await expect(page.getByText('Stage 2: Scoping')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 2: Scope')).toBeVisible({ timeout: 10000 })
 
     // Verify project name shows in header
     await expect(page.getByText(projectName)).toBeVisible()
@@ -102,11 +102,11 @@ test.describe('New UI Workflow', () => {
     await continueToStage3Button.click()
 
     // =====================
-    // STAGE 3: Drafting
+    // STAGE 3: Draft
     // =====================
 
     // Wait for Stage 3 form to load
-    await expect(page.getByText('Stage 3: Drafting')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 3: Draft')).toBeVisible({ timeout: 10000 })
 
     // Verify project name shows in header
     await expect(page.getByText(projectName)).toBeVisible()
@@ -258,7 +258,7 @@ test.describe('New UI Workflow', () => {
     await waitForLiveStoreReady(page)
 
     // Wait for Stage 1 form
-    await expect(page.getByText('Stage 1: Identifying')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 1: Identify')).toBeVisible({ timeout: 10000 })
 
     // Fill in title and category only (minimum required)
     const titleInput = page.locator('input[placeholder*="project called"]')

--- a/packages/web/src/components/new/drafting-room/DraftingRoom.tsx
+++ b/packages/web/src/components/new/drafting-room/DraftingRoom.tsx
@@ -77,9 +77,9 @@ function getLifecycleState(project: Project): ProjectLifecycleState {
 
 // Stage configuration (3 stages - Stage 4 happens in the Sorting Room)
 const STAGES: { stage: PlanningStage; name: string; emptyMessage: string }[] = [
-  { stage: 1, name: 'Identifying', emptyMessage: "Click 'Start New Project' to begin" },
-  { stage: 2, name: 'Scoping', emptyMessage: 'Complete Stage 1 projects to move them here' },
-  { stage: 3, name: 'Drafting', emptyMessage: 'Define objectives to advance projects' },
+  { stage: 1, name: 'Identify', emptyMessage: "Click 'Start New Project' to begin" },
+  { stage: 2, name: 'Scope', emptyMessage: 'Complete Stage 1 projects to move them here' },
+  { stage: 3, name: 'Draft', emptyMessage: 'Define objectives to advance projects' },
 ]
 
 // Category filter options (All + categories)

--- a/packages/web/src/components/new/drafting-room/Stage1Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage1Form.tsx
@@ -179,7 +179,7 @@ export const Stage1Form: React.FC = () => {
         {/* Header */}
         <div className='mb-6'>
           <h1 className="font-['Source_Serif_4',Georgia,serif] text-2xl font-bold text-[#2f2b27] mb-1">
-            Stage 1: Identifying
+            Stage 1: Identify
           </h1>
           <p className='text-sm text-[#8b8680]'>Quick capture - 2 minutes</p>
         </div>

--- a/packages/web/src/components/new/drafting-room/Stage2Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage2Form.tsx
@@ -249,7 +249,7 @@ export const Stage2Form: React.FC = () => {
         {/* Header */}
         <div className='mb-6'>
           <h1 className="font-['Source_Serif_4',Georgia,serif] text-2xl font-bold text-[#2f2b27] mb-1">
-            Stage 2: Scoping
+            Stage 2: Scope
           </h1>
           <p className='text-sm text-[#8b8680]'>Define what success looks like - 10 minutes</p>
         </div>

--- a/packages/web/src/components/new/drafting-room/Stage3Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage3Form.tsx
@@ -12,14 +12,12 @@ import {
 import { useAuth } from '../../../contexts/AuthContext.js'
 import { generateRoute } from '../../../constants/routes.js'
 import { StageWizard, type WizardStage } from './StageWizard.js'
-import { useRoomChatControl } from '../layout/RoomLayout.js'
 
 export const Stage3Form: React.FC = () => {
   const navigate = useNavigate()
   const { projectId } = useParams<{ projectId: string }>()
   const { store } = useStore()
   const { user } = useAuth()
-  const { openChat, sendDirectMessage } = useRoomChatControl()
 
   // Load existing project
   const projectResults = useQuery(getProjectById$(projectId ?? ''))
@@ -236,7 +234,7 @@ export const Stage3Form: React.FC = () => {
         {/* Header */}
         <div className='mb-6'>
           <h1 className="font-['Source_Serif_4',Georgia,serif] text-2xl font-bold text-[#2f2b27] mb-1">
-            Stage 3: Drafting
+            Stage 3: Draft
           </h1>
           <p className='text-sm text-[#8b8680]'>Create actionable task list - 30 minutes</p>
         </div>
@@ -297,29 +295,6 @@ export const Stage3Form: React.FC = () => {
                 Add
               </button>
             </div>
-
-            {/* Ask Marvin button */}
-            <button
-              type='button'
-              className='w-full py-2.5 px-4 rounded-lg text-sm font-medium bg-gradient-to-r from-purple-500 to-indigo-500 text-white cursor-pointer border-none transition-all duration-200 hover:from-purple-600 hover:to-indigo-600'
-              onClick={() => {
-                const existingTasks = tasks.map(t => t.title).join(', ')
-
-                let message = `Please help me draft a task list for this project.`
-                if (existingTasks) {
-                  message += ` I already have these tasks: ${existingTasks}.`
-                }
-                message += ` Please suggest additional tasks to complete this project. Ask me clarifying questions if you need more context about the project scope or goals.`
-
-                // Open the chat panel
-                openChat()
-
-                // Send the message with navigation context attached
-                sendDirectMessage(message)
-              }}
-            >
-              ✨ Ask Marvin to draft tasks
-            </button>
           </div>
         </div>
 

--- a/packages/web/src/components/new/drafting-room/StageWizard.tsx
+++ b/packages/web/src/components/new/drafting-room/StageWizard.tsx
@@ -14,9 +14,9 @@ interface StageWizardProps {
 }
 
 const STAGES: { stage: WizardStage; label: string }[] = [
-  { stage: 1, label: 'Identifying' },
-  { stage: 2, label: 'Scoping' },
-  { stage: 3, label: 'Drafting' },
+  { stage: 1, label: 'Identify' },
+  { stage: 2, label: 'Scope' },
+  { stage: 3, label: 'Draft' },
 ]
 
 export const StageWizard: React.FC<StageWizardProps> = ({
@@ -92,25 +92,6 @@ export const StageWizard: React.FC<StageWizardProps> = ({
                 )}
               </button>
             </React.Fragment>
-          )
-        })}
-      </div>
-
-      {/* Stage labels */}
-      <div className='flex justify-between mt-2 px-0'>
-        {STAGES.map(({ stage, label }) => {
-          const isActive = stage === currentStage
-          const isAccessible = stage <= maxAccessibleStage
-
-          return (
-            <span
-              key={stage}
-              className={`text-xs font-medium flex-1 text-center ${
-                isActive ? 'text-[#2f2b27]' : isAccessible ? 'text-[#8b8680]' : 'text-[#d0ccc5]'
-              }`}
-            >
-              {label}
-            </span>
           )
         })}
       </div>


### PR DESCRIPTION
## Summary
- Remove misaligned stage labels from StageWizard (now shows only numbered indicators)
- Remove purple gradient "Ask Marvin to draft tasks" button from Stage 3 form
- Rename stage names from gerund form to imperative: Identifying → Identify, Scoping → Scope, Drafting → Draft
- Update E2E tests to match new stage names

## Test plan
- [x] Lint passes (`pnpm lint-all`)
- [x] Unit tests pass (`pnpm test`)
- [x] E2E tests pass (`CI=true pnpm test:e2e`)
- [ ] Visual verification: stage wizard shows only numbered circles without text labels
- [ ] Visual verification: Stage 3 form no longer has purple gradient button

Closes #375
Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames drafting stages (Identifying/Scoping/Drafting → Identify/Scope/Draft), removes StageWizard text labels and the Stage 3 “Ask Marvin” button, and updates E2E tests accordingly.
> 
> - **Drafting Room UI**:
>   - Rename stage labels in `DraftingRoom.tsx`, `Stage1Form.tsx`, `Stage2Form.tsx`, `Stage3Form.tsx`, and `StageWizard.tsx` to `Identify`, `Scope`, `Draft`.
>   - Remove StageWizard label row (keeps numbered dots only) in `StageWizard.tsx`.
>   - Remove Stage 3 "Ask Marvin" button and related chat control code from `Stage3Form.tsx`.
> - **E2E Tests**:
>   - Update assertions in `e2e/new-ui-workflow.spec.ts` to reflect new stage names and UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61421c70936b7c4e3843022f84275346dcafd283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->