### PR TITLE
Update E2E test to match renamed stage labels

### DIFF
--- a/packages/web/e2e/drafting-room-back-button.spec.ts
+++ b/packages/web/e2e/drafting-room-back-button.spec.ts
@@ -36,7 +36,7 @@ test.describe('Drafting Room - Browser Back Button', () => {
     await page.goto(`/drafting-room/new?storeId=${storeId}`)
     await waitForLiveStoreReady(page)
 
-    await expect(page.getByText('Stage 1: Identifying')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 1: Identify')).toBeVisible({ timeout: 10000 })
 
     // Fill in initial project title
     const titleInput = page.locator('input[placeholder*="project called"]')
@@ -64,7 +64,7 @@ test.describe('Drafting Room - Browser Back Button', () => {
     // STAGE 2: Verify we're on Stage 2
     // =====================
 
-    await expect(page.getByText('Stage 2: Scoping')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 2: Scope')).toBeVisible({ timeout: 10000 })
     await expect(page.getByText(initialTitle)).toBeVisible()
 
     // =====================
@@ -77,7 +77,7 @@ test.describe('Drafting Room - Browser Back Button', () => {
     // STAGE 1: Change the title
     // =====================
 
-    await expect(page.getByText('Stage 1: Identifying')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 1: Identify')).toBeVisible({ timeout: 10000 })
 
     // Wait for LiveStore to load the project data
     await page.waitForTimeout(500)
@@ -105,7 +105,7 @@ test.describe('Drafting Room - Browser Back Button', () => {
     // STAGE 2: Verify updated title shows (not both titles)
     // =====================
 
-    await expect(page.getByText('Stage 2: Scoping')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 2: Scope')).toBeVisible({ timeout: 10000 })
 
     // Should show the updated title
     await expect(page.getByText(updatedTitle)).toBeVisible()
@@ -136,7 +136,7 @@ test.describe('Drafting Room - Browser Back Button', () => {
     // STAGE 3: Verify we only have ONE project with the updated title
     // =====================
 
-    await expect(page.getByText('Stage 3: Drafting')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 3: Draft')).toBeVisible({ timeout: 10000 })
     await expect(page.getByText(updatedTitle)).toBeVisible()
 
     // Exit to Drafting Room to verify only one project exists


### PR DESCRIPTION
## Summary
- Update `drafting-room-back-button.spec.ts` test to match the stage label changes from PR #379
- Changed assertions from "Stage N: Identifying/Scoping/Drafting" to "Stage N: Identify/Scope/Draft"

## Context
PR #379 renamed stage labels from gerund form to imperative form but missed updating this E2E test file, causing CI failures on main.

## Test plan
- [x] `pnpm lint-all` passes
- [x] `pnpm test` passes (563 tests)
- [x] `CI=true pnpm test:e2e` passes (32 passed, 11 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes e2e assertions to use renamed stage labels: "Identify", "Scope", and "Draft".
> 
> - **E2E**:
>   - Update stage label expectations in `packages/web/e2e/drafting-room-back-button.spec.ts`:
>     - `Stage 1: Identifying` → `Stage 1: Identify`
>     - `Stage 2: Scoping` → `Stage 2: Scope`
>     - `Stage 3: Drafting` → `Stage 3: Draft`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e86d56ea486bdcfd5b6a0b5c66b94e0ecb4c4ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->