### PR TITLE
Add diagnostic logging to investigate Sentry pino integration

### DIFF
--- a/packages/server/src/services/agentic-loop/agentic-loop.ts
+++ b/packages/server/src/services/agentic-loop/agentic-loop.ts
@@ -214,7 +214,8 @@ export class AgenticLoop {
         completedSuccessfully = true
         break
       } catch (error) {
-        log.error({ error, iteration }, `Error in iteration`)
+        // Use 'err' key for proper pino error serialization
+        log.error({ err: error, iteration, _diagnostic: 'iteration_error' }, `Error in iteration`)
 
         // Check if this is a transient error that we should retry
         const isTransientError = this.isTransientError(error)
@@ -234,7 +235,10 @@ export class AgenticLoop {
         }
 
         // For non-transient errors or after max retries, emit error and complete gracefully
-        log.error(`Fatal error or max retries reached, aborting loop`)
+        log.error(
+          { err: error, iteration, retryAttempts, _diagnostic: 'fatal_error' },
+          `Fatal error or max retries reached, aborting loop`
+        )
         this.events.onError?.(error as Error, iteration)
 
         // Send user-friendly error message

--- a/packages/server/src/services/agentic-loop/tool-executor.ts
+++ b/packages/server/src/services/agentic-loop/tool-executor.ts
@@ -55,7 +55,8 @@ export class ToolExecutor {
       this.options.onToolComplete?.(result)
       return result
     } catch (error) {
-      logger.error({ error, toolName: toolCall.function.name }, 'Tool execution error')
+      // Use 'err' key for proper pino error serialization
+      logger.error({ err: error, toolName: toolCall.function.name }, 'Tool execution error')
       const errorObj = error as Error
       this.options.onToolError?.(errorObj, toolCall)
 


### PR DESCRIPTION
## Summary

This PR adds diagnostic logging to help investigate why agentic loop logs aren't appearing in Sentry Logs.

### Changes

1. **Diagnostic logs using base logger** - Added explicit logs before/after agentic loop execution to verify if ANY logs during request processing reach Sentry:
   - `DIAGNOSTIC: Starting agentic loop (base logger)`
   - `DIAGNOSTIC: Agentic loop completed (base logger)`
   - `DIAGNOSTIC: Agentic loop error (base logger with err key)`

2. **Fixed pino error serialization** - Changed `{ error }` to `{ err }` in log calls:
   - Pino's standard error serializer only processes objects with key `err`
   - Using `error` key resulted in `{}` (empty object) in the JSON output
   - Updated in `agentic-loop.ts`, `tool-executor.ts`, and `event-processor.ts`

3. **Added `_diagnostic` marker** - All diagnostic logs include `_diagnostic: '<type>'` to easily filter in Sentry.

### Investigation Context

- Server initialization logs DO appear in Sentry Logs
- Agentic loop logs (which use child loggers) do NOT appear
- The pinoIntegration uses Node.js diagnostics channels which should work with child loggers
- This PR helps determine if the issue is with:
  - Child loggers specifically
  - All logs during async request processing
  - Error object serialization

### How to Test

After deploying, trigger an agent error and check Sentry Logs for:
- `_diagnostic: "agentic_loop_start"` - Should appear when chat message is processed
- `_diagnostic: "agentic_loop_complete"` - Should appear after successful completion
- `_diagnostic: "agentic_loop_error"` - Should appear on errors

If diagnostic logs appear but regular agentic loop logs don't, the issue is likely with child loggers.
If no diagnostic logs appear, there's a deeper issue with Sentry integration during request processing.

## Test plan

- [x] Lint passes (`pnpm lint-all`)
- [x] Unit tests pass (`pnpm test`)
- [ ] Deploy and send a chat message to trigger agentic loop
- [ ] Check Sentry Logs for diagnostic entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves observability of the agentic loop and tool execution for Sentry debugging.
> 
> - Adds diagnostic info logs before and after agentic loop (`_diagnostic: 'agentic_loop_start' | 'agentic_loop_complete'`) and on errors (`_diagnostic: 'agentic_loop_error'`) in `event-processor.ts`
> - Standardizes error logging to Pino's `{err}` key with contextual fields/markers in `agentic-loop.ts` (`iteration_error`, `fatal_error`) and `tool-executor.ts` (tool name), plus enhanced error logging in `event-processor.ts`
> - Preserves existing control flow; retries/backoff and completion/error events unchanged aside from enriched log metadata
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02c2e53ba5d3556d0fa5637b1301fb0b988386d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->