### PR TITLE
Add merge_from_example to conductor-setup for new env variables

### DIFF
--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -75,6 +75,12 @@ merge_from_example() {
     fi
 
     local added_vars=()
+    local needs_newline=false
+
+    # Check if dest file ends with a newline (to avoid corrupting last line)
+    if [ -s "$dest_path" ] && [ "$(tail -c 1 "$dest_path" | wc -l)" -eq 0 ]; then
+        needs_newline=true
+    fi
 
     # Read each line from example file
     while IFS= read -r line || [ -n "$line" ]; do
@@ -87,6 +93,11 @@ merge_from_example() {
 
             # Check if this variable exists in dest file
             if ! grep -q "^${var_name}=" "$dest_path"; then
+                # Add newline first if needed (only once, before first append)
+                if [ "$needs_newline" = true ]; then
+                    echo "" >> "$dest_path"
+                    needs_newline=false
+                fi
                 # Append the line from example
                 echo "$line" >> "$dest_path"
                 added_vars+=("$var_name")


### PR DESCRIPTION
## Summary
- Adds `merge_from_example()` function to conductor-setup.sh that merges missing variables from example files into copied env files
- Ensures new variables added to `.env.example` / `.dev.vars.example` files are automatically picked up in worktrees
- Reports which variables were added during setup

## Problem
When setting up worktrees, conductor copies env files from the root repo. If a developer's root env files are outdated (missing new variables that were added to the example files), the worktree would be missing those variables and things wouldn't work.

For example, the `SERVER_WEBHOOK_URL` and `WEBHOOK_SECRET` variables for workspace tracking were added to the examples but developers with older env files wouldn't have them.

## Solution
After copying env files, the script now:
1. Reads variables from each `.example` file
2. Checks if each variable exists in the copied env file
3. Appends any missing variables with their default values
4. Reports which variables were added

## Test plan
- [ ] Create a new worktree with outdated root env files (missing some variables from examples)
- [ ] Verify the missing variables are added and reported during setup
- [ ] Verify the worktree works correctly with the merged variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds automatic syncing of env files with their examples to prevent missing variables in worktrees.
> 
> - New `merge_from_example()` scans `.env.example`/`.dev.vars.example` and appends any missing `KEY=value` entries to destination env files (handles comments/empties and ensures final newline)
> - Invoked for `packages/web/.env`, `packages/server/.env`, `packages/worker/.dev.vars`, and `packages/auth-worker/.dev.vars` after copying from root
> - Outputs a concise report of which variables were added
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9d08259edc0b8e3582cf95588d48fce03c27823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->