### PR TITLE
Fix issue 433: Projects created via API now appear in Identify view

### DIFF
--- a/packages/server/src/tools/projects.ts
+++ b/packages/server/src/tools/projects.ts
@@ -80,13 +80,15 @@ function createProjectCore(
     const now = new Date()
 
     // PR4: Use v2.ProjectCreated event with category support
+    // Must include lifecycleState explicitly - the materializer fallback doesn't work
+    // reliably when events are synced from server to client
     store.commit(
       events.projectCreatedV2({
         id: projectId,
         name: params.name,
         description: params.description,
         category: params.category as any,
-        attributes: undefined,
+        lifecycleState: { status: 'planning', stage: 1 },
         createdAt: now,
         actorId,
       })


### PR DESCRIPTION
## Problem
Projects created via the `create_project` API tool weren't appearing in the Drafting Room UI's Identify view, even though they were successfully created and visible in API responses.

## Root Cause
The API's `createProjectCore` function wasn't including `lifecycleState` in the `projectCreatedV2` event. While the materializer has fallback logic, it doesn't work reliably when events are synced from server to client.

## Solution
Explicitly include `lifecycleState: { status: 'planning', stage: 1 }` in the event, matching the behavior of UI-created projects. This ensures newly created projects have the correct default state for the planning workflow.

## Tests
- `pnpm lint-all` - passed
- `pnpm test` - all 571 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures API-created projects are materialized with the correct default planning state so they show up in Identify.
> 
> - In `createProjectCore`, adds `lifecycleState: { status: 'planning', stage: 1 }` to `events.projectCreatedV2(...)`
> - Removes unused `attributes` field from the event payload
> - Notes: columns creation remains removed; tasks rely on `status`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feb749c8ef173108e939d5d33d1eb6d28f8fe995. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->