### PR TITLE
Fix issue #393: Marvin can bypass required field when drafting

### DIFF
--- a/packages/server/src/tools/projects.test.ts
+++ b/packages/server/src/tools/projects.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the logger to avoid console output during tests
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+// Create a mock store factory
+function createMockStore(
+  overrides: {
+    projects?: any[]
+    tasks?: any[]
+    projectLifecycleState?: any
+  } = {}
+) {
+  const { projects = [], tasks = [], projectLifecycleState = null } = overrides
+
+  const projectsWithLifecycle = projects.map(p => ({
+    ...p,
+    projectLifecycleState: p.projectLifecycleState ?? projectLifecycleState,
+  }))
+
+  return {
+    query: vi.fn((queryObj: any) => {
+      // Handle getBoardTasks$ query (used for task validation)
+      if (queryObj?.label?.startsWith('getBoardTasks:')) {
+        return tasks
+      }
+      // Handle getProjectDetails$ query
+      if (queryObj?.label?.startsWith('getProjectDetails:')) {
+        return projectsWithLifecycle
+      }
+      return []
+    }),
+    commit: vi.fn(),
+  }
+}
+
+describe('updateProjectLifecycle validation', () => {
+  // We'll test the validation logic by importing and calling the function directly
+  // Since the function is not exported directly, we test through the exported wrapper
+
+  describe('Stage 3+ validation (objectives and stream required)', () => {
+    it('should reject advancing to stage 3 without objectives', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 2,
+              stream: 'gold', // Has stream but no objectives
+            },
+          },
+        ],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 3,
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('objectives')
+    })
+
+    it('should reject advancing to stage 3 without stream/tier', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 2,
+              objectives: 'Test objectives', // Has objectives but no stream
+            },
+          },
+        ],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 3,
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('project type')
+    })
+
+    it('should reject advancing to stage 3 with empty objectives string', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 2,
+              objectives: '   ', // Empty/whitespace only
+              stream: 'gold',
+            },
+          },
+        ],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 3,
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('objectives')
+    })
+
+    it('should allow advancing to stage 3 with objectives and stream', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 2,
+              objectives: 'Test objectives',
+              stream: 'gold',
+            },
+          },
+        ],
+        tasks: [], // No tasks yet (not required for stage 3)
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 3,
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockStore.commit).toHaveBeenCalled()
+    })
+
+    it('should allow providing objectives and stream in the same call as stage advance', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 2,
+              // No objectives or stream yet
+            },
+          },
+        ],
+        tasks: [],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 3,
+          objectives: 'New objectives',
+          stream: 'silver',
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockStore.commit).toHaveBeenCalled()
+    })
+  })
+
+  describe('Stage 4 / backlog validation (tasks required)', () => {
+    it('should reject advancing to stage 4 without tasks', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 3,
+              objectives: 'Test objectives',
+              stream: 'gold',
+            },
+          },
+        ],
+        tasks: [], // No tasks
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 4,
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('task')
+    })
+
+    it('should reject moving to backlog without tasks', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 3,
+              objectives: 'Test objectives',
+              stream: 'gold',
+            },
+          },
+        ],
+        tasks: [], // No tasks
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          status: 'backlog',
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('task')
+    })
+
+    it('should not count archived tasks when validating', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 3,
+              objectives: 'Test objectives',
+              stream: 'gold',
+            },
+          },
+        ],
+        tasks: [
+          { id: 'task-1', archivedAt: new Date() }, // Archived task shouldn't count
+        ],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 4,
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('task')
+    })
+
+    it('should allow advancing to stage 4 with at least one non-archived task', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 3,
+              objectives: 'Test objectives',
+              stream: 'gold',
+            },
+          },
+        ],
+        tasks: [
+          { id: 'task-1', archivedAt: null }, // Non-archived task
+        ],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 4,
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockStore.commit).toHaveBeenCalled()
+    })
+
+    it('should allow moving to backlog with tasks', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 3,
+              objectives: 'Test objectives',
+              stream: 'gold',
+            },
+          },
+        ],
+        tasks: [{ id: 'task-1', archivedAt: null }],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          status: 'backlog',
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockStore.commit).toHaveBeenCalled()
+    })
+  })
+
+  describe('Earlier stage updates (no validation required)', () => {
+    it('should allow updating stage 1 project without restrictions', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 1,
+            },
+          },
+        ],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          stage: 2,
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockStore.commit).toHaveBeenCalled()
+    })
+
+    it('should allow updating lifecycle fields at stage 2 without advancing', async () => {
+      const { updateProjectLifecycle } = await import('./projects.js')
+
+      const mockStore = createMockStore({
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Test Project',
+            projectLifecycleState: {
+              status: 'planning',
+              stage: 2,
+            },
+          },
+        ],
+      })
+
+      const result = updateProjectLifecycle(
+        mockStore as any,
+        {
+          projectId: 'project-1',
+          objectives: 'Setting objectives',
+          stream: 'bronze',
+        },
+        'actor-1'
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockStore.commit).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds server-side validation to `updateProjectLifecycleCore` to match UI validation rules
- Stage 3+ now requires objectives (non-empty) AND project type/stream (not null)
- Stage 4 or backlog status now requires at least one non-archived task
- Adds comprehensive unit tests for the new validation logic

Fixes #393

## Test plan
- [x] Unit tests pass covering all validation scenarios
- [x] E2E tests pass
- [ ] Manual test: Create project via Marvin without objectives → should fail with clear error
- [ ] Manual test: Create project via Marvin without project type → should fail with clear error  
- [ ] Manual test: Try to move project to backlog without tasks via Marvin → should fail with clear error
- [ ] Manual test: Normal UI workflow still works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens backend parity with UI by validating project lifecycle transitions on the server.
> 
> - Enforces in `updateProjectLifecycleCore` that stage ≥3 requires non-empty `objectives` and a `stream`/tier
> - Requires at least one non-archived task for stage 4 or status `backlog` using `getBoardTasks$`
> - Returns clear error messages instead of committing invalid lifecycle updates
> - Adds `projects.test.ts` with unit tests covering acceptance/rejection cases, including archived-task handling and updating fields without advancing stages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ae0e10b90cef8eb0c75969622a42e54519d6632. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->