### PR TITLE
Rename Drafting Room Stage 3 from 'Draft' to 'Detail'

### DIFF
--- a/packages/shared/src/rooms.ts
+++ b/packages/shared/src/rooms.ts
@@ -75,7 +75,7 @@ Projects flow through these statuses:
    - **Urgency**: low, normal, high, critical
    - **Importance**: low, normal, high, critical
 
-3. **Drafting (Stage 3)**: Finalize the plan
+3. **Detailing (Stage 3)**: Finalize the plan
    - Write clear objectives
    - Set a deadline (optional)
    - Estimate duration in hours (optional)

--- a/packages/shared/src/types/planning.ts
+++ b/packages/shared/src/types/planning.ts
@@ -383,6 +383,6 @@ export const ARCHETYPE_LABELS: Record<ProjectArchetype, string> = {
 export const STAGE_LABELS: Record<PlanningStage, string> = {
   1: 'Identifying',
   2: 'Scoping',
-  3: 'Drafting',
+  3: 'Detailing',
   4: 'Prioritizing',
 }

--- a/packages/web/e2e/drafting-room-back-button.spec.ts
+++ b/packages/web/e2e/drafting-room-back-button.spec.ts
@@ -132,7 +132,7 @@ test.describe('Drafting Room - Browser Back Button', () => {
     // STAGE 3: Verify we only have ONE project with the updated title
     // =====================
 
-    await expect(page.getByText('Stage 3: Draft')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 3: Detail')).toBeVisible({ timeout: 10000 })
     await expect(page.getByText(updatedTitle)).toBeVisible()
 
     // Exit to Drafting Room to verify only one project exists

--- a/packages/web/e2e/new-ui-workflow.spec.ts
+++ b/packages/web/e2e/new-ui-workflow.spec.ts
@@ -98,11 +98,11 @@ test.describe('New UI Workflow', () => {
     await continueToStage3Button.click()
 
     // =====================
-    // STAGE 3: Draft
+    // STAGE 3: Detail
     // =====================
 
     // Wait for Stage 3 form to load
-    await expect(page.getByText('Stage 3: Draft')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Stage 3: Detail')).toBeVisible({ timeout: 10000 })
 
     // Verify project name shows in header
     await expect(page.getByText(projectName)).toBeVisible()

--- a/packages/web/src/components/new/drafting-room/DraftingRoom.tsx
+++ b/packages/web/src/components/new/drafting-room/DraftingRoom.tsx
@@ -79,7 +79,7 @@ function getLifecycleState(project: Project): ProjectLifecycleState {
 const STAGES: { stage: PlanningStage; name: string; emptyMessage: string }[] = [
   { stage: 1, name: 'Identify', emptyMessage: "Click 'Start New Project' to begin" },
   { stage: 2, name: 'Scope', emptyMessage: 'Complete Stage 1 projects to move them here' },
-  { stage: 3, name: 'Draft', emptyMessage: 'Define objectives to advance projects' },
+  { stage: 3, name: 'Detail', emptyMessage: 'Define objectives to advance projects' },
 ]
 
 // Category filter options (All + categories)

--- a/packages/web/src/components/new/drafting-room/PlanningQueueCard.tsx
+++ b/packages/web/src/components/new/drafting-room/PlanningQueueCard.tsx
@@ -30,7 +30,7 @@ function formatCompactRelativeTime(date: Date): string {
  * Get the action button label based on the current stage (imperative verbs)
  * Stage 1: "Identify" (continue identifying)
  * Stage 2: "Scope" (continue scoping)
- * Stage 3: "Draft" (continue drafting)
+ * Stage 3: "Detail" (continue detailing)
  * Stage 4: "Prioritize" (continue prioritizing)
  */
 function getActionLabel(stage: PlanningStage): string {
@@ -40,7 +40,7 @@ function getActionLabel(stage: PlanningStage): string {
     case 2:
       return 'Scope'
     case 3:
-      return 'Draft'
+      return 'Detail'
     case 4:
       return 'Prioritize'
     default:

--- a/packages/web/src/components/new/drafting-room/Stage2Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage2Form.tsx
@@ -158,7 +158,7 @@ export const Stage2Form: React.FC = () => {
   }
 
   /**
-   * Save and advance to Stage 3 (Drafting)
+   * Save and advance to Stage 3 (Detailing)
    * Only called when all required fields are complete
    */
   const saveAndAdvance = () => {

--- a/packages/web/src/components/new/drafting-room/Stage3Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage3Form.tsx
@@ -349,7 +349,7 @@ export const Stage3Form: React.FC = () => {
         {/* Header */}
         <div className='mb-4'>
           <h1 className="font-['Source_Serif_4',Georgia,serif] text-2xl font-bold text-[#2f2b27]">
-            Stage 3: Draft
+            Stage 3: Detail
           </h1>
         </div>
 

--- a/packages/web/src/components/new/drafting-room/StageWizard.tsx
+++ b/packages/web/src/components/new/drafting-room/StageWizard.tsx
@@ -16,7 +16,7 @@ interface StageWizardProps {
 const STAGES: { stage: WizardStage; label: string }[] = [
   { stage: 1, label: 'Identify' },
   { stage: 2, label: 'Scope' },
-  { stage: 3, label: 'Draft' },
+  { stage: 3, label: 'Detail' },
 ]
 
 export const StageWizard: React.FC<StageWizardProps> = ({

--- a/packages/web/src/hooks/useNavigationContext.ts
+++ b/packages/web/src/hooks/useNavigationContext.ts
@@ -22,7 +22,7 @@ function detectCurrentView(pathname: string): string | undefined {
     return 'Stage 2: Scoping - User is defining objectives, archetype, and tier'
   }
   if (pathname.includes('/stage3')) {
-    return 'Stage 3: Drafting - User is creating an actionable task list'
+    return 'Stage 3: Detailing - User is creating an actionable task list'
   }
   if (pathname === '/drafting-room') {
     return 'Drafting Room - Overview of all projects in planning stages 1-3'


### PR DESCRIPTION
## Summary
Renames Stage 3 of the Drafting Room from "Draft" to "Detail" to better convey the purpose of the stage. Stage 3 is about creating an itemized list of all the steps needed for a successful project, and "Detail" works as both a noun (an individual feature/fact) and a verb (describe item by item).

## Changes
- Updated stage labels, UI components, form headers, and test expectations across 10 files
- All existing tests pass (571 unit tests, 4 relevant E2E tests)

## Verification
- lint-all: ✓ passed
- unit tests: ✓ 571 passed  
- E2E tests: ✓ 4 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes Stage 3 terminology to "Detail/Detailing" across the app.
> 
> - Updates `STAGE_LABELS` and `DRAFTING_ROOM_PROMPT` to use "Detailing"
> - Changes UI labels/headers in `DraftingRoom`, `StageWizard`, `Stage3Form`, and `PlanningQueueCard` to "Detail"
> - Aligns navigation context string and E2E tests (`new-ui-workflow.spec.ts`, `drafting-room-back-button.spec.ts`) with the new wording
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d609353251fd21d43586946f2cc72fc8befe1314. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->