### PR TITLE
Rename project statuses for clarity (#405)

### DIFF
--- a/packages/shared/src/rooms.ts
+++ b/packages/shared/src/rooms.ts
@@ -50,11 +50,11 @@ Help users plan, scope, and organize their projects through the planning stages 
 
 ## Project Lifecycle
 
-Projects flow through these statuses:
-- **planning**: Projects in stages 1-3, actively being defined
-- **backlog**: Stage 4 projects waiting to be worked on (in the Sorting Room)
-- **active**: Currently being worked on (on the "table")
-- **completed**: Done
+Projects flow through these statuses (internal status value → display name):
+- **planning** → "Drafting": Projects in stages 1-3, actively being defined
+- **backlog** → "Sorting": Stage 4 projects waiting to be worked on (in the Sorting Room)
+- **active** → "Active": Currently being worked on (on the "table")
+- **completed** → "Completed": Done
 
 ## Planning Stages (Drafting Room handles stages 1-3)
 
@@ -120,7 +120,7 @@ const SORTING_ROOM_PROMPT = `You are Cameron, the Priority Queue specialist for 
 Your role is to help users manage their priority queue and make tough prioritization decisions across three streams: Gold, Silver, and Bronze.
 
 ## Priority Queue Overview
-The Sorting Room displays all projects in "backlog" status (Stage 4) ready for activation. Projects are filtered into three streams based on their archetype and scale:
+The Sorting Room displays all projects in "backlog" status (Stage 4, displayed as "Sorting") ready for activation. Projects are filtered into three streams based on their archetype and scale:
 
 ### Three-Stream System
 - **Gold Stream**: Major initiatives (archetype: 'initiative' with major/epic scale). Typically 2-8 projects. These are frontier-opening, life-changing work. Only ONE Gold project can be active at a time.

--- a/packages/shared/src/types/planning.ts
+++ b/packages/shared/src/types/planning.ts
@@ -355,9 +355,9 @@ export const describeProjectLifecycleState = (
   const streamLabel = STREAM_LABELS[lifecycle.stream ?? 'bronze']
   switch (lifecycle.status) {
     case 'planning':
-      return `Planning · Stage ${lifecycle.stage}`
+      return `Drafting · Stage ${lifecycle.stage}`
     case 'backlog':
-      return `Backlog · ${streamLabel}`
+      return `Sorting · ${streamLabel}`
     case 'active':
       return `Active${lifecycle.slot ? ` · ${STREAM_LABELS[lifecycle.slot]} slot` : ''}`
     case 'completed':

--- a/packages/web/e2e/new-ui-workflow.spec.ts
+++ b/packages/web/e2e/new-ui-workflow.spec.ts
@@ -134,10 +134,10 @@ test.describe('New UI Workflow', () => {
       await expect(page.getByText(taskName)).toBeVisible()
     }
 
-    // Click Add to Backlog
-    const addToBacklogButton = page.getByRole('button', { name: 'Add to Backlog' })
-    await expect(addToBacklogButton).toBeEnabled()
-    await addToBacklogButton.click()
+    // Click Add to Sorting
+    const addToSortingButton = page.getByRole('button', { name: 'Add to Sorting' })
+    await expect(addToSortingButton).toBeEnabled()
+    await addToSortingButton.click()
 
     // =====================
     // SORTING ROOM: Put on table

--- a/packages/web/src/components/new/drafting-room/Stage3Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage3Form.tsx
@@ -463,7 +463,7 @@ export const Stage3Form: React.FC = () => {
             onClick={handleContinue}
             disabled={!hasAtLeastOneTask}
           >
-            Add to Backlog
+            Add to Sorting
           </button>
         </div>
       </div>

--- a/packages/web/src/components/new/projects/ProjectCard.stories.tsx
+++ b/packages/web/src/components/new/projects/ProjectCard.stories.tsx
@@ -192,12 +192,12 @@ const meta: Meta<typeof ProjectCardHelper> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Planning: Story = {
+export const Drafting: Story = {
   args: { projectId: 'project-planning' },
   decorators: [withLiveStore(planningSetup)],
 }
 
-export const Backlog: Story = {
+export const Sorting: Story = {
   args: { projectId: 'project-backlog' },
   decorators: [withLiveStore(backlogSetup)],
 }

--- a/packages/web/src/components/new/sorting-room/GoldSilverPanel.tsx
+++ b/packages/web/src/components/new/sorting-room/GoldSilverPanel.tsx
@@ -248,7 +248,7 @@ export const GoldSilverPanel: React.FC<GoldSilverPanelProps> = ({
                 }}
                 onClick={() => setQueueView('backlog')}
               >
-                Backlog ({backlogProjects.length})
+                Sorting ({backlogProjects.length})
               </button>
               <button
                 type='button'
@@ -266,7 +266,7 @@ export const GoldSilverPanel: React.FC<GoldSilverPanelProps> = ({
             {displayedProjects.length === 0 ? (
               <div className='p-4 text-[#8b8680] text-sm italic'>
                 {queueView === 'backlog'
-                  ? `No projects in backlog. Complete Stage 4 in the Drafting Room to add projects.`
+                  ? `No projects in sorting. Complete Stage 4 in the Drafting Room to add projects.`
                   : `No active projects.`}
               </div>
             ) : (


### PR DESCRIPTION
## Summary
Rename user-facing project status labels to better reflect their purpose:
- "Planning" → "Drafting" (projects in stages 1-3 of the planning process)
- "Backlog" → "Sorting" (stage 4 projects in the Sorting Room waiting for prioritization)

## Changes
- Updated display function in `describeProjectLifecycleState`
- Updated UI labels in Stage3Form and GoldSilverPanel
- Updated Storybook stories for ProjectCard
- Updated AI prompt documentation for clarity
- Updated E2E tests to use new label names

Internal status values remain unchanged for backwards compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns user-facing lifecycle labels with new terminology and updates references across code and tests.
> 
> - Update `describeProjectLifecycleState` to return `Drafting` for `planning` and `Sorting` for `backlog`
> - Change UI copy: Stage 3 CTA to `Add to Sorting`, Sorting panel tab/empty-state text to `Sorting`
> - Adjust E2E workflow assertions to use new labels
> - Rename Storybook stories: `Planning`→`Drafting`, `Backlog`→`Sorting`
> - Clarify AI room prompts with explicit status→display-name mapping and Sorting Room description
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ad863e01ce4f2f8e8c334dedcab97a8e46df07d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->