### PR TITLE
Allow pressing Enter to submit task creation form

### DIFF
--- a/packages/web/src/components/new/project-room/TaskDetailModal.tsx
+++ b/packages/web/src/components/new/project-room/TaskDetailModal.tsx
@@ -325,7 +325,7 @@ export function TaskDetailModal({
   }
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault()
       handleSave()
     }


### PR DESCRIPTION
## Summary
Enable users to create tasks in the Drafting Room by pressing Enter on the title or deadline field, improving the form UX for quick task creation.

## Changes
- Added `handleInputKeyDown` handler that submits the form when Enter is pressed
- Applied the handler to title and deadline inputs (textarea intentionally excluded to preserve newline behavior)

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves task creation/edit UX in `TaskDetailModal` by enabling Enter-to-save on key inputs.
> 
> - Adds `handleInputKeyDown` to submit via `handleSave()` when Enter is pressed, ignoring IME composing
> - Hooks the handler to the title `input` and deadline `input[type="date"]` in edit mode
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b1999a113ef60029e921c7498656007de39c42c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->