### PR TITLE
Fix orphan_task tool not actually orphaning tasks

### DIFF
--- a/packages/shared/src/livestore/schema.ts
+++ b/packages/shared/src/livestore/schema.ts
@@ -864,7 +864,8 @@ const materializers = State.SQLite.materializers(events, {
     tasks.update({ position, updatedAt }).where({ id: taskId }),
 
   'v2.TaskMovedToProject': ({ taskId, toProjectId, position, updatedAt }) =>
-    tasks.update({ projectId: toProjectId, position, updatedAt }).where({ id: taskId }),
+    // Use ?? null to ensure undefined toProjectId is explicitly set to null (for orphaning tasks)
+    tasks.update({ projectId: toProjectId ?? null, position, updatedAt }).where({ id: taskId }),
 
   'v2.TaskAttributesUpdated': ({ taskId, attributes, updatedAt }) =>
     tasks


### PR DESCRIPTION
## Summary

- Fixed a bug where the `orphan_task` tool reported success but tasks remained associated with their projects
- The issue was in the `v2.TaskMovedToProject` materializer: when `toProjectId` was `undefined`, the update statement didn't set `projectId` to `null` (it likely skipped the field entirely)
- Added explicit `?? null` coercion to ensure `undefined` values are converted to `null`

## Test plan

- [x] Verified all unit tests pass
- [x] Verified all E2E tests pass
- [ ] Manual test: Use the orphan_task tool on a task and verify it's removed from its project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures tasks are actually orphaned when moved off a project.
> 
> - Updates `v2.TaskMovedToProject` in `schema.ts` to use `projectId: toProjectId ?? null`, preventing the update from skipping `projectId` when `toProjectId` is `undefined`.
> - Adds an inline comment documenting the explicit nulling behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d821fba8990342b4c1e8f2343056317e718c9b33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->