### PR TITLE
Add project management section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,12 @@ gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> --field-id <STATUS
 - When creating a PR: Set status to "In Review"
 - Issues auto-close on merge when PR description includes `Closes #XXX`
 
+### Project Management
+
+- **Parent Issues**: Only use the "Parent issue" feature for issues with type "Project". Never set a parent issue on regular issues.
+- **Sub-issues**: Use the GraphQL `addSubIssue` mutation to link issues as sub-issues to Project-type issues
+- **Adding to Projects**: Use `gh project item-add <project-number> --owner sociotechnica-org --url <issue-url>`
+
 ### Common Workflows
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds Project Management section with guidance on parent issues, sub-issues, and adding items to projects
- Combines with the existing Project Board Commands section from main

## Test plan
- [x] Rebased onto main and resolved conflicts
- [x] Both sections are present and properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documentation-only update to `CLAUDE.md` adding concise project management guidance.
> 
> - **New `Project Management` section** with rules for `Parent issue` (only for Project-type), linking sub-issues via GraphQL `addSubIssue`, and adding issues to projects using `gh project item-add`
> - Complements existing Project Board commands for status updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4944f4904f61d8f356ff3c0d6aa1dbc29bbde14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->