### PR TITLE
Fix: Server no longer crashes when a single store fails to initialize

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -84,6 +84,10 @@ async function main() {
       await workspaceOrchestrator.ensureMonitored(storeId)
     } catch (error) {
       logger.error({ storeId, error }, 'Failed to start monitoring store, continuing with others')
+      Sentry.captureException(error, {
+        tags: { storeId },
+        extra: { phase: 'ensureMonitored', degradedMode: true },
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes crash loop when one store fails to initialize (e.g., `danvers-personal-lb` with stale local data)
- Server now gracefully degrades: working stores continue, failed stores are logged and skipped
- Only monitors stores that successfully initialized instead of attempting to re-add failed stores

## Root Cause

The agentic server on Render was crash-looping because:
1. `danvers-personal-lb` store had stale local data (head: 453) while sync backend had head: 454
2. LiveStore threw `shouldNeverHappen` error during boot
3. Server then tried to call `ensureMonitored` for all configured stores, including the failed one
4. Re-adding the failed store threw the same error, crashing the server
5. Render detected crash loop and suspended the service

## Test plan

- [ ] Merge this PR
- [ ] Server should start successfully, monitoring only `jess-personal-lb`
- [ ] Logs should show warning about `danvers-personal-lb` being skipped
- [ ] Separately, need to fix the `danvers-personal-lb` data issue (clear local data or troubleshoot sync)

## Follow-up needed

After merging, we still need to fix the underlying data issue for `danvers-personal-lb`. Options:
1. Clear the local data directory for that store on Render
2. Investigate why the sync state diverged

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves startup robustness by avoiding crash loops when a store fails to initialize.
> 
> - Monitor only `initializedStoreIds` from `storeManager.getAllStores()` instead of all configured `storeIds`
> - Wrap `ensureMonitored(storeId)` in try/catch per store; on failure, log error and `Sentry.captureException` with `storeId` tags and degraded mode context
> - Compute and warn about `skippedStores`; update startup `logger.info` to include `monitoredCount` and `skippedCount`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae55253aec4cda397ace46e82f159e00dfbe113f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->