### PR TITLE
fix(server): fix memory leaks in EventProcessor reconnection handling

### DIFF
--- a/packages/server/src/services/event-processor.ts
+++ b/packages/server/src/services/event-processor.ts
@@ -12,6 +12,7 @@ import { ProcessedMessageTracker } from './processed-message-tracker.js'
 import { logger, storeLogger, createContextLogger, logMessageEvent } from '../utils/logger.js'
 import {
   getMessageLifecycleTracker,
+  destroyMessageLifecycleTracker,
   type MessageLifecycleTracker,
 } from './message-lifecycle-tracker.js'
 import {
@@ -1642,6 +1643,9 @@ export class EventProcessor {
     this.processedTracker.close().catch(error => {
       logger.error({ error }, 'Error closing processed message tracker')
     })
+
+    // Cleanup global message lifecycle tracker (stops its cleanup timer)
+    destroyMessageLifecycleTracker()
 
     logger.info('Stopped all event monitoring')
   }


### PR DESCRIPTION
This commit fixes two memory leaks in the render server's EventProcessor:

1. When startMonitoring() fails to create subscriptions, the already-created
   storeState (with its MessageQueueManager timer) was not cleaned up before
   throwing. The MessageQueueManager's cleanup interval would keep running
   indefinitely.

2. When reconnections occur via forceCleanupStoreState() or stopMonitoring(),
   the llmProvider was not being explicitly cleared, and the stopping flag
   was not set to signal in-flight operations to abort.

Changes:
- Add cleanup in startMonitoring() when no subscriptions can be created
- Set stopping=true in forceCleanupStoreState() to signal in-flight ops
- Clear llmProvider reference in both cleanup methods for consistency

https://claude.ai/code/session_01RNxuqY85obpZK7wW4h3xGw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses resource leaks and race conditions in `EventProcessor` lifecycle.
> 
> - Add failure-path cleanup in `startMonitoring()` when no subscriptions are created: set `stopping`, destroy `messageQueue`, clear `llmProvider`, remove state, and clear `monitoringStartTime`.
> - Strengthen reconnection cleanup in `forceCleanupStoreState()`: set `stopping`, destroy queues and per-conversation processors, clear `llmProvider`, and remove health-tracking/state entries.
> - Ensure `stopMonitoring()` also clears `llmProvider` during final cleanup.
> - Call `destroyMessageLifecycleTracker()` in `stopAll()` to stop its cleanup timer.
> 
> These changes improve shutdown/restart correctness and prevent timers, providers, or processors from lingering after teardown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4077afcea042a87ef6cb9ab304e8114f9028e51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->