### PR TITLE
Remove Roster Room from navigation

### DIFF
--- a/packages/web/src/components/new/layout/NewUiShell.tsx
+++ b/packages/web/src/components/new/layout/NewUiShell.tsx
@@ -131,12 +131,6 @@ export const NewUiShell: React.FC<NewUiShellProps> = ({
             Sorting Room
           </Link>
           <Link
-            to='#'
-            className='no-underline text-[#8b8680] py-2 px-3 rounded-xl opacity-50 pointer-events-none'
-          >
-            Roster Room
-          </Link>
-          <Link
             to={generateRoute.lifeMap()}
             className={`no-underline py-2 px-3 rounded-xl transition-all duration-[160ms] ${
               isActive('/life-map')


### PR DESCRIPTION
## Summary

Hide Roster Room from the navigation until the feature is ready for launch.

## Test Plan

- Lint and tests pass
- Navigation no longer displays Roster Room

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the placeholder "Roster Room" link from the header navigation to hide the unfinished feature.
> 
> - Deletes the disabled `Roster Room` `<Link>` in `NewUiShell.tsx`, leaving `Drafting Room`, `Sorting Room`, and `Life Map` in the nav
> - No routing, data, or logic changes; UI-only cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96e1707b67b13f752ca630c148e5cf155f0de724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->