### PR TITLE
Recover backend head mismatches before LiveStore boot

### DIFF
--- a/packages/server/src/factories/store-factory.ts
+++ b/packages/server/src/factories/store-factory.ts
@@ -3,6 +3,8 @@ import { makeAdapter } from '@livestore/adapter-node'
 import { makeWsSync } from '@livestore/sync-cf/client'
 import { schema } from '@lifebuild/shared/schema'
 import path from 'path'
+import fs from 'fs'
+import Database from 'better-sqlite3'
 import { logger } from '../utils/logger.js'
 
 export interface StoreConfig {
@@ -61,6 +63,82 @@ export function getStoreConfig(storeId: string): StoreConfig {
   return baseConfig
 }
 
+const EVENTLOG_PREFIX = 'eventlog@'
+
+function findEventlogPath(storeDataPath: string, storeId: string): string | null {
+  const candidateDirs = [storeDataPath, path.join(storeDataPath, storeId)]
+
+  for (const dir of candidateDirs) {
+    if (!fs.existsSync(dir)) continue
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (!entry.isFile()) continue
+      if (entry.name.startsWith(EVENTLOG_PREFIX) && entry.name.endsWith('.db')) {
+        return path.join(dir, entry.name)
+      }
+    }
+  }
+
+  // Fall back to one-level deep search under storeDataPath
+  if (fs.existsSync(storeDataPath)) {
+    const entries = fs.readdirSync(storeDataPath, { withFileTypes: true })
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const dir = path.join(storeDataPath, entry.name)
+      const nested = fs.readdirSync(dir, { withFileTypes: true })
+      for (const file of nested) {
+        if (!file.isFile()) continue
+        if (file.name.startsWith(EVENTLOG_PREFIX) && file.name.endsWith('.db')) {
+          return path.join(dir, file.name)
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+async function repairBackendHeadIfAhead(storeDataPath: string, storeId: string): Promise<void> {
+  try {
+    const eventlogPath = findEventlogPath(storeDataPath, storeId)
+    if (!eventlogPath) {
+      return
+    }
+
+    const db = new Database(eventlogPath)
+    try {
+      const headRow = db.prepare('select head from __livestore_sync_status').get() as
+        | { head?: number }
+        | undefined
+      const localRow = db.prepare('select max(seqNumGlobal) as maxHead from eventlog').get() as
+        | { maxHead?: number }
+        | undefined
+
+      if (!headRow) return
+
+      const backendHead = headRow.head ?? 0
+      const localHead = localRow?.maxHead ?? 0
+
+      if (backendHead > localHead) {
+        logger.warn(
+          {
+            storeId,
+            backendHead,
+            localHead,
+            eventlogPath,
+          },
+          'Backend head ahead of local head; resetting backend head to local head for recovery'
+        )
+        db.prepare('update __livestore_sync_status set head = ?').run(localHead)
+      }
+    } finally {
+      db.close()
+    }
+  } catch (error) {
+    logger.warn({ storeId, error }, 'Failed to repair backend head before LiveStore boot')
+  }
+}
+
 /**
  * Creates the sync payload for server-worker authentication
  * Uses SERVER_BYPASS_TOKEN for both production and development
@@ -115,6 +193,10 @@ export async function createStore(
   )
 
   const storeDataPath = path.join(config.dataPath!, storeId)
+
+  if (process.env.LIVESTORE_REPAIR_BACKEND_HEAD !== 'false') {
+    await repairBackendHeadIfAhead(storeDataPath, storeId)
+  }
 
   const adapter = makeAdapter({
     storage: {

--- a/packages/server/src/factories/store-factory.ts
+++ b/packages/server/src/factories/store-factory.ts
@@ -139,6 +139,11 @@ async function repairBackendHeadIfAhead(storeDataPath: string, storeId: string):
   }
 }
 
+export const __test__ = {
+  findEventlogPath,
+  repairBackendHeadIfAhead,
+}
+
 /**
  * Creates the sync payload for server-worker authentication
  * Uses SERVER_BYPASS_TOKEN for both production and development


### PR DESCRIPTION
## Summary
- repair local sync status when backend head is ahead of local eventlog
- log recovery details for store boot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pre-boot recovery to align LiveStore backend head with local eventlog when mismatched.
> 
> - New `findEventlogPath` and `repairBackendHeadIfAhead` scan `dataPath` for `eventlog@*.db` and, via `better-sqlite3`, reset `__livestore_sync_status.head` to local `max(seqNumGlobal)` if backend head is ahead
> - Invoked during `createStore` (guarded by `LIVESTORE_REPAIR_BACKEND_HEAD !== 'false'`) with structured warning logs for visibility
> - Introduces tests validating head correction and no-op when local head is ahead
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2861fe13d9a5c66ef593b879060e9dab37b8dbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->