### PR TITLE
Update LiveStore recovery plan with findings

### DIFF
--- a/docs/plans/038-livestore-recovery/README.md
+++ b/docs/plans/038-livestore-recovery/README.md
@@ -132,6 +132,18 @@ This plan restores production access for jess-personal-lb, establishes a repeata
     or stored under a previous persistence format version (PERSISTENCE_FORMAT_VERSION) not being read.
   - Web client mismatch is downstream of backend history, not purely a client cache issue.
 
+### 2026-01-26: Current state (freeze)
+- Front-end, server, and sync backend are now aligned and showing the same dataset.
+- Project is frozen at this state by request.
+
+## Recovery Patch (Server)
+### Backend head repair at boot
+- Added a pre-boot check in `packages/server/src/factories/store-factory.ts` that:
+  - Locates the local eventlog database for a store.
+  - Reads `__livestore_sync_status.head` and compares it to `max(seqNumGlobal)` from `eventlog`.
+  - If backend head is ahead, updates it to the local head and logs a recovery warning.
+- This is intended to prevent boot failure when backend head > local head.
+
 ## Open Questions
 - What caused the original materializer crash or state divergence?
 - Are there schema/materializer changes deployed recently that would trigger this?


### PR DESCRIPTION
## Summary
- record minimal wipe results and current freeze state
- document server-side LiveStore recovery patch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the recovery plan with concrete findings and a documented server-side mitigation.
> 
> - **Adds** a Recovery Notes log with results of a minimal wipe test and records the current "freeze" state alignment across front-end/server/backend
> - **Documents** a server recovery patch: pre-boot check in `packages/server/src/factories/store-factory.ts` to compare `__livestore_sync_status.head` with `eventlog` head and repair when backend > local, logging a warning
> - Clarifies operational steps to prevent boot failure when backend head is ahead, tying into the runbook
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff89102afe029719baa34d46d27e18112692c84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->