### PR TITLE
Track store connection status history

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,7 +18,7 @@ import * as Sentry from '@sentry/node'
 // Static imports are hoisted and resolved before any code runs, so
 // any module that transitively imports logger.js would defeat the purpose.
 const { logger } = await import('./utils/logger.js')
-const { storeManager } = await import('./services/store-manager.js')
+const { serializeStoreConnectionFields, storeManager } = await import('./services/store-manager.js')
 const { EventProcessor } = await import('./services/event-processor.js')
 const { WorkspaceOrchestrator } = await import('./services/workspace-orchestrator.js')
 const { AuthWorkerWorkspaceDirectory } = await import('./services/workspace-directory.js')
@@ -306,12 +306,7 @@ async function main() {
         id,
         status: info.status,
         connectedAt: info.connectedAt.toISOString(),
-        lastConnectedAt: info.lastConnectedAt?.toISOString() ?? null,
-        lastDisconnectedAt: info.lastDisconnectedAt?.toISOString() ?? null,
-        statusHistory: info.statusHistory.map(entry => ({
-          status: entry.status,
-          timestamp: entry.timestamp.toISOString(),
-        })),
+        ...serializeStoreConnectionFields(info),
         lastActivity: info.lastActivity.toISOString(),
         errorCount: info.errorCount,
         reconnectAttempts: info.reconnectAttempts,

--- a/packages/server/src/services/store-manager.ts
+++ b/packages/server/src/services/store-manager.ts
@@ -46,6 +46,24 @@ export interface StoreInfo {
   networkStatus?: NetworkStatusInfo
 }
 
+export const serializeStoreConnectionFields = (
+  info: StoreInfo
+): {
+  lastConnectedAt: string | null
+  lastDisconnectedAt: string | null
+  statusHistory: Array<{
+    status: StoreConnectionStatus
+    timestamp: string
+  }>
+} => ({
+  lastConnectedAt: info.lastConnectedAt?.toISOString() ?? null,
+  lastDisconnectedAt: info.lastDisconnectedAt?.toISOString() ?? null,
+  statusHistory: info.statusHistory.map(entry => ({
+    status: entry.status,
+    timestamp: entry.timestamp.toISOString(),
+  })),
+})
+
 /** Event signatures for StoreManager - used for documentation */
 interface StoreManagerEvents {
   storeReconnected: (data: { storeId: string; store: LiveStore }) => void
@@ -837,12 +855,7 @@ export class StoreManager extends EventEmitter {
       storeId,
       status: info.status,
       connectedAt: info.connectedAt.toISOString(),
-      lastConnectedAt: info.lastConnectedAt?.toISOString() ?? null,
-      lastDisconnectedAt: info.lastDisconnectedAt?.toISOString() ?? null,
-      statusHistory: info.statusHistory.map(entry => ({
-        status: entry.status,
-        timestamp: entry.timestamp.toISOString(),
-      })),
+      ...serializeStoreConnectionFields(info),
       lastActivity: info.lastActivity.toISOString(),
       errorCount: info.errorCount,
       reconnectAttempts: info.reconnectAttempts,


### PR DESCRIPTION
## Summary
- track lastConnectedAt/lastDisconnectedAt and capped status history in StoreManager
- route status updates through history recorder for disconnect/reconnect transitions
- expose status history fields in /stores JSON output

## Testing
- pnpm lint-all
- pnpm test
- CI=true pnpm test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive observability changes plus a small refactor of status updates; risk is limited to potential behavior changes around when `storeDisconnected` is emitted or timestamps are recorded.
> 
> **Overview**
> Adds per-store connection lifecycle tracking in `StoreManager`, recording `lastConnectedAt`, `lastDisconnectedAt`, and a capped `statusHistory`, and routes all status transitions through a new `updateStoreStatus()` helper to avoid duplicate updates/emits.
> 
> Extends `/stores` and `getHealthStatus()` JSON output to include these new connection fields via `serializeStoreConnectionFields()` (timestamps serialized to ISO strings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd50b39082ce18db85e3ae71fdc048d317d1b31e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->