### PR TITLE
Fiber cleanup for store monitoring streams

### DIFF
--- a/packages/server/src/services/store-manager.ts
+++ b/packages/server/src/services/store-manager.ts
@@ -434,10 +434,7 @@ export class StoreManager extends EventEmitter {
           // Stream ended - check if this is from the current store or a stale (replaced) one
           const storeInfo = this.stores.get(storeId)
           if (storeInfo && storeInfo.monitoringSessionId !== sessionId) {
-            storeLogger(storeId).debug(
-              { error },
-              'Network status stream stopped intentionally'
-            )
+            storeLogger(storeId).debug({ error }, 'Network status stream stopped intentionally')
             return
           }
           if (storeInfo && storeInfo.store !== originalStore) {


### PR DESCRIPTION
## Summary
- run store monitoring streams in fibers with scoped error handling
- interrupt monitoring fibers on store shutdown/reconnect
- track monitoring fibers in store info

## Testing
- pnpm lint-all
- pnpm test
- CI=true pnpm test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches store connection monitoring and reconnection behavior; mistakes could cause missed disconnect detection or extra reconnect churn, but scope is localized to `StoreManager`.
> 
> **Overview**
> Runs store `networkStatus`/`syncState` monitoring streams in background fibers and tracks them on `StoreInfo`, rather than `runPromise` fire-and-forget.
> 
> Adds `stopMonitoring()` with a `monitoringSessionId` guard to interrupt old fibers on store removal/reconnect and ignore stale stream events; also tightens error handling so unexpected network-status stream termination marks the store `disconnected` and triggers reconnect while intentional/stale shutdowns are logged quietly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c6132f5ec90b5c62c172e86b2b535b9a99f541c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->