### PR TITLE
Add Sentry alerts on store disconnects

### DIFF
--- a/packages/server/src/services/store-manager.ts
+++ b/packages/server/src/services/store-manager.ts
@@ -1,12 +1,14 @@
 import type { Store as LiveStore, SyncState } from '@livestore/livestore'
 import { StoreInternalsSymbol } from '@livestore/livestore'
 import { Effect, Fiber, Stream } from '@livestore/utils/effect'
+import * as Sentry from '@sentry/node'
 import { EventEmitter } from 'events'
 import { type StoreConfig, createStore } from '../factories/store-factory.js'
 import { logger, storeLogger, operationLogger } from '../utils/logger.js'
 import {
   createOrchestrationTelemetry,
   getIncidentDashboardUrl,
+  unwrapErrorForSentry,
 } from '../utils/orchestration-telemetry.js'
 
 export type StoreConnectionStatus = 'connected' | 'connecting' | 'disconnected' | 'error'
@@ -368,6 +370,7 @@ export class StoreManager extends EventEmitter {
           if (!initial.isConnected && storeInfo.status === 'connected') {
             storeLogger(storeId).warn('Network disconnected on startup - updating status')
             if (this.updateStoreStatus(storeId, 'disconnected', now)) {
+              this.captureDisconnect(storeId, storeInfo, 'startup_network_disconnected')
               this.emit('storeDisconnected', { storeId })
             }
           }
@@ -424,6 +427,7 @@ export class StoreManager extends EventEmitter {
             disconnectedSince: now,
           }
           if (this.updateStoreStatus(storeId, 'disconnected', now)) {
+            this.captureDisconnect(storeId, storeInfo, 'network_status_disconnected')
             this.emit('storeDisconnected', { storeId })
           }
         }
@@ -460,6 +464,7 @@ export class StoreManager extends EventEmitter {
               disconnectedSince: now,
             }
             if (this.updateStoreStatus(storeId, 'disconnected', now)) {
+              this.captureDisconnect(storeId, storeInfo, 'network_status_stream_ended', error)
               this.emit('storeDisconnected', { storeId })
             }
             this.scheduleReconnect(storeId)
@@ -654,6 +659,7 @@ export class StoreManager extends EventEmitter {
         'Sync appears stuck - triggering reconnection'
       )
       if (this.updateStoreStatus(storeId, 'disconnected')) {
+        this.captureDisconnect(storeId, storeInfo, 'sync_stuck')
         this.emit('storeDisconnected', { storeId })
       }
       this.scheduleReconnect(storeId)
@@ -772,6 +778,7 @@ export class StoreManager extends EventEmitter {
             if (!storeInfo.networkStatus.isConnected && storeInfo.status === 'connected') {
               // Network is disconnected but we haven't updated our status yet
               if (this.updateStoreStatus(storeId, 'disconnected')) {
+                this.captureDisconnect(storeId, storeInfo, 'health_check_network_disconnected')
                 this.emit('storeDisconnected', { storeId })
               }
               storeLogger(storeId).warn('Network disconnected - updating status')
@@ -825,6 +832,41 @@ export class StoreManager extends EventEmitter {
 
     // Start the first health check
     this.healthCheckInterval = setTimeout(runHealthCheck, healthCheckInterval)
+  }
+
+  private captureDisconnect(
+    storeId: string,
+    storeInfo: StoreInfo,
+    reason: string,
+    error?: unknown
+  ): void {
+    if (this.isShuttingDown) {
+      return
+    }
+    const syncUrl = storeInfo.config.syncUrl ?? 'unknown'
+    const unwrappedError = error ? unwrapErrorForSentry(error) : undefined
+    const errorToCapture =
+      unwrappedError instanceof Error
+        ? unwrappedError
+        : error
+          ? new Error(`Store disconnected: ${reason} (${String(error)})`)
+          : new Error(`Store disconnected: ${reason}`)
+    Sentry.withScope(scope => {
+      scope.setTag('storeId', storeId)
+      scope.setTag('syncUrl', syncUrl)
+      scope.setTag('reason', reason)
+      if (error) {
+        scope.setContext('disconnectError', {
+          message:
+            unwrappedError instanceof Error
+              ? unwrappedError.message
+              : unwrappedError
+                ? String(unwrappedError)
+                : String(error),
+        })
+      }
+      Sentry.captureException(errorToCapture)
+    })
   }
 
   async shutdown(): Promise<void> {


### PR DESCRIPTION
## Summary
- capture Sentry exceptions when a store disconnects, tagging events with storeId, syncUrl, and reason

## Testing
- pnpm lint-all
- pnpm test
- PLAYWRIGHT_PORT=5174 CI=true pnpm test:e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational-only change that adds Sentry reporting on existing disconnect paths; main risk is increased alert noise or missing context if tagging/error unwrapping is incorrect.
> 
> **Overview**
> Adds Sentry exception capture whenever a store transitions to `disconnected`, covering startup network-down, network status change/stream termination, health-check detected disconnects, and stuck-sync recovery.
> 
> Introduces a centralized `captureDisconnect()` helper that tags events with `storeId`, `syncUrl`, and a `reason`, optionally unwrapping/capturing the underlying error details, and skips emitting during shutdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65fbdf1572fa68d6483aa1ecf037aab769c6a8c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->