### PR TITLE
Fix update_document tool failing with missing title/content

### DIFF
--- a/packages/server/src/services/agentic-loop/braintrust-provider.test.ts
+++ b/packages/server/src/services/agentic-loop/braintrust-provider.test.ts
@@ -21,6 +21,33 @@ describe('BraintrustProvider', () => {
     vi.useRealTimers()
   })
 
+  describe('API request configuration', () => {
+    it('should use max_tokens of 4096 to support document content in tool calls', async () => {
+      const mockMessages: LLMMessage[] = [{ role: 'user', content: 'test message' }]
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [
+              {
+                message: {
+                  content: 'test response',
+                  tool_calls: [],
+                },
+              },
+            ],
+          }),
+      })
+
+      await provider.call(mockMessages)
+
+      // Verify fetch was called with max_tokens: 4096
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(fetchBody.max_tokens).toBe(4096)
+    })
+  })
+
   describe('timeout error handling', () => {
     const mockMessages: LLMMessage[] = [{ role: 'user', content: 'test message' }]
 

--- a/packages/server/src/services/agentic-loop/braintrust-provider.ts
+++ b/packages/server/src/services/agentic-loop/braintrust-provider.ts
@@ -160,7 +160,7 @@ When users describe project requirements or ask you to create tasks, use the cre
             tools,
             tool_choice: 'auto',
             temperature: 0.7,
-            max_tokens: 1000,
+            max_tokens: 4096,
           }),
           signal: controller.signal,
         })
@@ -188,6 +188,18 @@ When users describe project requirements or ask you to create tasks, use the cre
 
         if (!responseMessage) {
           throw new Error('No response generated from LLM')
+        }
+
+        // Warn if response was truncated due to token limit - tool call arguments may be incomplete
+        if (choice.finish_reason === 'length') {
+          logger.warn(
+            {
+              model: model || DEFAULT_MODEL,
+              hasToolCalls: !!responseMessage.tool_calls?.length,
+              finishReason: choice.finish_reason,
+            },
+            'LLM response truncated due to max_tokens limit - tool call arguments may be incomplete'
+          )
         }
 
         logger.info(

--- a/packages/server/src/tools/documents.test.ts
+++ b/packages/server/src/tools/documents.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the schema imports before importing the module under test
+vi.mock('@lifebuild/shared/schema', () => ({
+  events: {
+    documentUpdated: vi.fn(params => params),
+    documentCreated: vi.fn(params => params),
+  },
+}))
+
+vi.mock('@lifebuild/shared/queries', () => ({
+  getDocumentById$: vi.fn((id: string) => `getDocumentById$:${id}`),
+  getDocumentList$: 'getDocumentList$',
+  searchDocuments$: vi.fn(),
+  searchDocumentsWithProject$: vi.fn(),
+  getAllDocuments$: 'getAllDocuments$',
+  getDocumentProjectsByProject$: vi.fn(),
+  getProjects$: 'getProjects$',
+}))
+
+// Import after mocks are set up
+import type { UpdateDocumentParams } from './types.js'
+
+describe('updateDocument', () => {
+  let updateDocument: any
+  let mockStore: any
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    // Create mock store
+    mockStore = {
+      query: vi.fn(),
+      commit: vi.fn(),
+    }
+
+    // Dynamic import to get the mocked version
+    const documentsModule = await import('./documents.js')
+    updateDocument = documentsModule.updateDocument
+  })
+
+  it('should return error when neither title nor content is provided', () => {
+    // Mock document exists
+    mockStore.query.mockReturnValue([
+      { id: 'doc-1', title: 'Existing Doc', content: 'Existing content' },
+    ])
+
+    const result = updateDocument(mockStore, { documentId: 'doc-1' } as UpdateDocumentParams)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('At least one field (title or content) must be provided')
+    expect(result.error).toContain('documentId="doc-1"')
+    expect(result.error).toContain('Please include a "title" and/or "content" parameter')
+  })
+
+  it('should succeed when title is provided', () => {
+    mockStore.query.mockReturnValue([
+      { id: 'doc-1', title: 'Old Title', content: 'Existing content' },
+    ])
+
+    const result = updateDocument(mockStore, {
+      documentId: 'doc-1',
+      title: 'New Title',
+    } as UpdateDocumentParams)
+
+    expect(result.success).toBe(true)
+    expect(result.document.title).toBe('New Title')
+    // Should include the existing content in the response
+    expect(result.document.content).toBe('Existing content')
+    expect(mockStore.commit).toHaveBeenCalled()
+  })
+
+  it('should succeed when content is provided', () => {
+    mockStore.query.mockReturnValue([
+      { id: 'doc-1', title: 'Existing Title', content: 'Old content' },
+    ])
+
+    const result = updateDocument(mockStore, {
+      documentId: 'doc-1',
+      content: 'New content',
+    } as UpdateDocumentParams)
+
+    expect(result.success).toBe(true)
+    expect(result.document.content).toBe('New content')
+    // Should include the existing title in the response
+    expect(result.document.title).toBe('Existing Title')
+    expect(mockStore.commit).toHaveBeenCalled()
+  })
+
+  it('should succeed when both title and content are provided', () => {
+    mockStore.query.mockReturnValue([{ id: 'doc-1', title: 'Old Title', content: 'Old content' }])
+
+    const result = updateDocument(mockStore, {
+      documentId: 'doc-1',
+      title: 'New Title',
+      content: 'New content',
+    } as UpdateDocumentParams)
+
+    expect(result.success).toBe(true)
+    expect(result.document.title).toBe('New Title')
+    expect(result.document.content).toBe('New content')
+    expect(mockStore.commit).toHaveBeenCalled()
+  })
+
+  it('should return error when document is not found', () => {
+    mockStore.query.mockReturnValue([])
+
+    const result = updateDocument(mockStore, {
+      documentId: 'nonexistent',
+      title: 'New Title',
+    } as UpdateDocumentParams)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not found')
+  })
+
+  it('should return error when title is empty string', () => {
+    mockStore.query.mockReturnValue([
+      { id: 'doc-1', title: 'Existing Title', content: 'Existing content' },
+    ])
+
+    const result = updateDocument(mockStore, {
+      documentId: 'doc-1',
+      title: '   ',
+    } as UpdateDocumentParams)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Document title cannot be empty')
+  })
+
+  it('should trim title and content', () => {
+    mockStore.query.mockReturnValue([{ id: 'doc-1', title: 'Old Title', content: 'Old content' }])
+
+    const result = updateDocument(mockStore, {
+      documentId: 'doc-1',
+      title: '  New Title  ',
+      content: '  New content  ',
+    } as UpdateDocumentParams)
+
+    expect(result.success).toBe(true)
+    expect(result.document.title).toBe('New Title')
+    expect(result.document.content).toBe('New content')
+  })
+})

--- a/packages/server/src/tools/documents.ts
+++ b/packages/server/src/tools/documents.ts
@@ -202,11 +202,15 @@ function updateDocumentCore(store: Store, params: UpdateDocumentParams): UpdateD
 
   // Verify document exists
   const documents = store.query(getDocumentById$(documentId))
-  validators.requireEntity(documents, 'Document', documentId)
+  const document = validators.requireEntity(documents, 'Document', documentId)
 
   // At least one field must be provided for update
   if (title === undefined && content === undefined) {
-    throw new Error('At least one field (title or content) must be provided for update')
+    throw new Error(
+      `At least one field (title or content) must be provided for update. ` +
+        `Received only: documentId="${documentId}". ` +
+        `Please include a "title" and/or "content" parameter with the new value.`
+    )
   }
 
   // Prepare updates object
@@ -230,12 +234,13 @@ function updateDocumentCore(store: Store, params: UpdateDocumentParams): UpdateD
     })
   )
 
+  // Return the full document state after update (merge current values with updates)
   return {
     success: true,
     document: {
       id: documentId,
-      title: updates.title,
-      content: updates.content,
+      title: updates.title ?? (document as any).title,
+      content: updates.content ?? (document as any).content,
     },
   }
 }


### PR DESCRIPTION
The update_document tool was consistently failing because the LLM's
response was being truncated by a max_tokens limit of 1000. When the
model tried to include document content in tool call arguments, the
token limit caused the JSON to be auto-closed without the title/content
fields, resulting in "At least one field must be provided" errors.

Changes:
- Increase max_tokens from 1000 to 4096 in braintrust provider to
  support document content in tool call arguments
- Add finish_reason check to warn when responses are truncated
- Improve error message to include received parameters for debugging
- Return full document state after update (merge updates with existing
  values) so the LLM sees complete document info
- Add comprehensive tests for update_document and max_tokens config

https://claude.ai/code/session_01ENqBVgLANqPoTFmg583iCq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises LLM `max_tokens` and changes document update responses, which can affect cost/latency and downstream agent behavior, but is localized and covered by new unit tests.
> 
> **Overview**
> Prevents `update_document` tool calls from failing due to LLM truncation by increasing Braintrust chat completion `max_tokens` from `1000` to `4096` and adding a warning log when `finish_reason === "length"`.
> 
> Improves `updateDocumentCore` to emit a more diagnostic error when neither `title` nor `content` is provided, and to return a merged document payload (preserving existing `title`/`content` when only one field is updated). Adds unit tests covering the new `max_tokens` configuration and `update_document` validation/merge behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 945d87c4764aa44c55fdea0a10b7eaa42c8e843d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->