### PR TITLE
Increase auth-worker rate limit from 10 to 60 req/min

### DIFF
--- a/packages/auth-worker/src/index.ts
+++ b/packages/auth-worker/src/index.ts
@@ -607,7 +607,7 @@ function createErrorResponse(message: string, status = 400): Response {
  */
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>()
 
-function checkRateLimit(clientIP: string, maxRequests = 10, windowMs = 60000): boolean {
+function checkRateLimit(clientIP: string, maxRequests = 60, windowMs = 60000): boolean {
   const now = Date.now()
   const key = clientIP
   const window = rateLimitStore.get(key)


### PR DESCRIPTION
## Summary

- Increases the per-IP rate limit on the auth worker from 10 to 60 requests per minute
- The previous limit was too aggressive for normal admin panel usage, causing 429 errors when clicking through users and workspaces

## Changelog

- Increase auth-worker rate limit from 10 to 60 requests per minute to prevent false 429 errors during normal usage

## Test plan

- [ ] Deploy to production and verify admin panel browsing no longer triggers 429s
- [ ] Verify rate limiting still works by exceeding 60 req/min (e.g. with a script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-constant change to rate limiting defaults; main risk is allowing higher request volume per IP, potentially increasing abuse or load.
> 
> **Overview**
> Increases the auth worker’s per-IP in-memory rate limit by changing `checkRateLimit`’s default from **10 to 60 requests per minute**, reducing unexpected `429 Too many requests` responses during normal usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d17f86c21790431bd40030f650c98a3778af9d8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->