### PR TITLE
docs: update work-squared references to lifebuild after repo rename

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout work-squared repo
+      - name: Checkout lifebuild repo
         uses: actions/checkout@v4
         with:
           ref: main
@@ -188,7 +188,7 @@ jobs:
             --body "$(cat <<EOF
           ## Changelog Entry
 
-          This PR adds a changelog entry for [work-squared PR #${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}).
+          This PR adds a changelog entry for [lifebuild PR #${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}).
 
           **Version:** ${{ steps.extract.outputs.new_version }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ We use GitHub Issues and Projects for all project management across the SocioTec
 
 ### Repository Organization
 
-- **`work-squared`**: Issues related to the LifeBuild app (features, bugs, technical work)
+- **`lifebuild`**: Issues related to the LifeBuild app (features, bugs, technical work)
 - **`company`**: Issues related to company-level activities (social media, marketing, partnerships, operations)
 
 ### Key Concepts
@@ -290,7 +290,7 @@ gh project item-add 2 --owner sociotechnica-org --url <issue-url>
 
 ```bash
 # List all Project issues
-gh issue list --search "type:Project" -R sociotechnica-org/work-squared
+gh issue list --search "type:Project" -R sociotechnica-org/lifebuild
 ```
 
 #### Sub-issues with gh-sub-issue extension
@@ -314,7 +314,7 @@ gh sub-issue create --parent 410 --title "New task for this project"
 gh sub-issue remove 410 415
 
 # When not in the repo directory, use -R flag
-gh sub-issue list 410 -R sociotechnica-org/work-squared
+gh sub-issue list 410 -R sociotechnica-org/lifebuild
 ```
 
 #### Sub-issues with REST API (no extension needed)
@@ -322,15 +322,15 @@ gh sub-issue list 410 -R sociotechnica-org/work-squared
 ```bash
 # Add a sub-issue to a project (using REST API)
 # Use -F (not -f) to pass integer values
-CHILD_ID=$(gh api repos/sociotechnica-org/work-squared/issues/123 --jq '.id')
-gh api repos/sociotechnica-org/work-squared/issues/100/sub_issues \
+CHILD_ID=$(gh api repos/sociotechnica-org/lifebuild/issues/123 --jq '.id')
+gh api repos/sociotechnica-org/lifebuild/issues/100/sub_issues \
   -X POST -F sub_issue_id="$CHILD_ID"
 
 # List sub-issues of a project
-gh api repos/sociotechnica-org/work-squared/issues/100/sub_issues
+gh api repos/sociotechnica-org/lifebuild/issues/100/sub_issues
 
 # View project in GitHub Project board
-# Filter: parent-issue:"sociotechnica-org/work-squared#100"
+# Filter: parent-issue:"sociotechnica-org/lifebuild#100"
 ```
 
 ### GitHub Project Views
@@ -338,7 +338,7 @@ gh api repos/sociotechnica-org/work-squared/issues/100/sub_issues
 Views must be created via the GitHub UI (no API available). Recommended views:
 
 - **All Projects**: Filter `type:Project` - shows all active projects
-- **[Project Name]**: Filter `parent-issue:"sociotechnica-org/work-squared#N"` - shows work for a specific project
+- **[Project Name]**: Filter `parent-issue:"sociotechnica-org/lifebuild#N"` - shows work for a specific project
 
 To create a view:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We track work using GitHub Issues and the [SocioTechnica Project Board](https://
 
 ### Creating a New Project
 
-Create a new GitHub Issue in the [work-squared repo](https://github.com/sociotechnica-org/work-squared/issues/new) with:
+Create a new GitHub Issue in the [lifebuild repo](https://github.com/sociotechnica-org/lifebuild/issues/new) with:
 
 - Issue type: **Project**
 - Title format: `Project: [Name]`
@@ -37,7 +37,7 @@ Create a new GitHub Issue in the [work-squared repo](https://github.com/sociotec
 
 ### Adding Issues to a Project
 
-1. Navigate to the Project issue (e.g., [#410](https://github.com/sociotechnica-org/work-squared/issues/410))
+1. Navigate to the Project issue (e.g., [#410](https://github.com/sociotechnica-org/lifebuild/issues/410))
 2. In the right sidebar, find **Sub-issues**
 3. Click **Add sub-issue** to link existing issues or create new ones
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -5,4 +5,4 @@ SENTRY_AUTH_TOKEN=sntryu_your_token_here
 
 # Sentry defaults (optional - can also pass via CLI flags)
 SENTRY_ORG=sociotechnica
-SENTRY_PROJECT=work-squared
+SENTRY_PROJECT=lifebuild

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -96,7 +96,7 @@ wrangler deployments list
 
 ### Sentry (Error Tracking)
 
-**Dashboard**: https://sociotechnica.sentry.io/issues/?project=work-squared
+**Dashboard**: https://sociotechnica.sentry.io/issues/?project=lifebuild
 
 **CLI Setup**:
 
@@ -119,13 +119,13 @@ sentry-cli info
 sentry-cli issues list
 
 # Or specify explicitly
-sentry-cli issues list --org sociotechnica --project work-squared
+sentry-cli issues list --org sociotechnica --project lifebuild
 
 # View specific issue
 sentry-cli issues show <issue-id>
 ```
 
-Project: `work-squared` (covers all LifeBuild services)
+Project: `lifebuild` (covers all LifeBuild services)
 
 ### PostHog (Product Analytics)
 

--- a/deploy/playbooks/001-server-down.md
+++ b/deploy/playbooks/001-server-down.md
@@ -66,7 +66,7 @@ Look for:
 
 Sentry captures exceptions with full stack traces and context.
 
-**Dashboard** (recommended): https://sociotechnica.sentry.io/issues/?project=work-squared
+**Dashboard** (recommended): https://sociotechnica.sentry.io/issues/?project=lifebuild
 
 Filter by:
 
@@ -79,7 +79,7 @@ Filter by:
 ```bash
 # Note: Default CI token may not have issue:read scope
 # Use dashboard if CLI returns 403
-sentry-cli issues list --org sociotechnica --project work-squared
+sentry-cli issues list --org sociotechnica --project lifebuild
 ```
 
 Look for:


### PR DESCRIPTION
## Summary

Update GitHub repo references from `sociotechnica-org/work-squared` to `sociotechnica-org/lifebuild` in active documentation. This reflects the completed repo rename. Preserves `work-squared.onrender.com` URLs as they are currently deployed infrastructure.

## Test Plan

Documentation review only—no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc/config-example and workflow-message-only changes; no runtime logic or production configuration is altered.
> 
> **Overview**
> Updates internal docs and ops references to reflect the repo rename from `work-squared` to `lifebuild` (README, `CLAUDE.md`, deploy docs/playbooks).
> 
> Adjusts the changelog automation workflow copy to reference “lifebuild PR” and updates Sentry example configuration/links (`deploy/.env.example`, `deploy/AGENTS.md`, and the server-down playbook) to use the `lifebuild` project slug.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf503f050a5c792973a044b6df63aad0591e7cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->