### PR TITLE
Improve typing responsiveness in project forms

### DIFF
--- a/packages/web/src/components/new/drafting-room/Stage1Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage1Form.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useStore, useQuery } from '../../../livestore-compat.js'
 import { events } from '@lifebuild/shared/schema'
@@ -23,7 +23,8 @@ export const Stage1Form: React.FC = () => {
   const posthog = usePostHog()
 
   // Load existing project if editing
-  const projectResults = useQuery(getProjectById$(urlProjectId ?? ''))
+  const projectQuery = useMemo(() => getProjectById$(urlProjectId ?? ''), [urlProjectId])
+  const projectResults = useQuery(projectQuery)
   const existingProject = urlProjectId ? (projectResults?.[0] ?? null) : null
 
   const [title, setTitle] = useState('')

--- a/packages/web/src/components/new/drafting-room/Stage2Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage2Form.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useStore, useQuery } from '../../../livestore-compat.js'
 import { events } from '@lifebuild/shared/schema'
@@ -64,7 +64,8 @@ export const Stage2Form: React.FC = () => {
   const posthog = usePostHog()
 
   // Load existing project (query returns array, get first item)
-  const projectResults = useQuery(getProjectById$(projectId ?? ''))
+  const projectQuery = useMemo(() => getProjectById$(projectId ?? ''), [projectId])
+  const projectResults = useQuery(projectQuery)
   const project = projectResults?.[0] ?? null
 
   // Form state - initialized empty, will be populated from project

--- a/packages/web/src/components/new/drafting-room/Stage3Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage3Form.tsx
@@ -153,11 +153,13 @@ export const Stage3Form: React.FC = () => {
   const { openChat, sendDirectMessage } = useRoomChatControl()
 
   // Load existing project
-  const projectResults = useQuery(getProjectById$(projectId ?? ''))
+  const projectQuery = useMemo(() => getProjectById$(projectId ?? ''), [projectId])
+  const projectResults = useQuery(projectQuery)
   const project = projectResults?.[0] ?? null
 
   // Load existing tasks for this project
-  const allTasks = useQuery(getProjectTasks$(projectId ?? '')) ?? []
+  const tasksQuery = useMemo(() => getProjectTasks$(projectId ?? ''), [projectId])
+  const allTasks = useQuery(tasksQuery) ?? []
   const tasks = useMemo(
     () => allTasks.filter(t => !t.archivedAt).sort((a, b) => a.position - b.position),
     [allTasks]

--- a/packages/web/src/components/project-creation/ProjectCreationView.tsx
+++ b/packages/web/src/components/project-creation/ProjectCreationView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom'
 import { useStore, useQuery } from '../../livestore-compat.js'
 import { events } from '@lifebuild/shared/schema'
@@ -93,7 +93,8 @@ export const ProjectCreationView: React.FC = () => {
   // Get project ID from URL if editing existing project
   const projectId = searchParams.get('projectId')
   // Always call useQuery unconditionally - use dummy ID when none exists to avoid hooks violations
-  const projectQueryResult = useQuery(getProjectDetails$(projectId || '__dummy__'))
+  const projectQuery = useMemo(() => getProjectDetails$(projectId || '__dummy__'), [projectId])
+  const projectQueryResult = useQuery(projectQuery)
   const existingProject = projectId ? (projectQueryResult?.[0] as any) : null
 
   // Stage management (only stages 1-2 are shown in UI, stage 3 navigates to workspace)

--- a/packages/web/src/hooks/useCategoryAdvisor.ts
+++ b/packages/web/src/hooks/useCategoryAdvisor.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useMemo } from 'react'
 import { useStore, useQuery } from '../livestore-compat.js'
 import { events } from '@lifebuild/shared/schema'
 import { getWorkerById$, getConversations$ } from '@lifebuild/shared/queries'
@@ -36,9 +36,8 @@ export function useCategoryAdvisor(category: ProjectCategory | null | undefined)
   const advisorId = category ? `${category}-advisor` : null
 
   // Query for the advisor worker
-  const advisorResult = useQuery(
-    advisorId ? getWorkerById$(advisorId) : getWorkerById$('__no_advisor__')
-  )
+  const advisorQuery = useMemo(() => getWorkerById$(advisorId ?? '__no_advisor__'), [advisorId])
+  const advisorResult = useQuery(advisorQuery)
   const advisor = advisorId && advisorResult?.[0] ? advisorResult[0] : null
 
   // For now, we'll check if advisor exists to determine readiness


### PR DESCRIPTION
## Summary
- memoize LiveStore queries used in drafting-room stages and legacy project creation
- memoize category advisor query to avoid per-keystroke query recreation

## Testing
- pnpm lint-all
- pnpm test
- CI=true pnpm test:e2e

## Changelog
- Improve typing responsiveness in project creation forms by reducing LiveStore query churn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure React hook/performance change (adds `useMemo` around query construction) with no behavioral changes to data mutations; low risk aside from potential stale-query bugs if dependency arrays are incorrect.
> 
> **Overview**
> Improves typing responsiveness in project creation/drafting forms by **memoizing LiveStore query builders** before passing them to `useQuery`.
> 
> This updates drafting-room `Stage1Form`, `Stage2Form`, and `Stage3Form` (including tasks loading) plus the legacy `ProjectCreationView` and `useCategoryAdvisor` to create stable query instances keyed by IDs, avoiding query re-creation on every render/keystroke.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a33a98dbc85f484152ca16248d2c52f91dc2b92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->