### PR TITLE
Make empty Table slots actionable with backlog selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,11 +143,13 @@ The app includes a repair mechanism for when local LiveStore data becomes incons
 ### Common Gotchas
 
 **Worker error handling:**
+
 - Errors in web workers do NOT propagate to the main thread automatically. React error boundaries and main-thread Sentry won't catch worker errors without explicit bridging.
 - Sentry must be initialized inside workers, or errors must be forwarded to the main thread.
 - Effect-TS `shouldNeverHappen` defects do NOT reach React error boundaries unless explicitly forwarded.
 
 **React performance with LiveStore:**
+
 - Use `useMemo` for stable references to adapter configs, context values, and expensive computations.
 - Adapter instances (e.g., `makeWebAdapter`) must be memoized — recreating them causes full LiveStore reconnections.
 - Use `useRef` for mutable state that persists across renders without triggering re-renders (e.g., timestamps, counters).

--- a/README.md
+++ b/README.md
@@ -277,4 +277,3 @@ LifeBuild is built with a modern monorepo architecture featuring real-time colla
 - **Backend**: Cloudflare Worker with Durable Objects and WebSocket sync
 - **AI Integration**: Client-side agentic loops with tool calling via LLM proxy
 - **Testing**: Vitest, React Testing Library, Playwright E2E tests
-

--- a/packages/web/e2e/drafting-room-back-button.spec.ts
+++ b/packages/web/e2e/drafting-room-back-button.spec.ts
@@ -119,7 +119,8 @@ test.describe('Drafting Room - Browser Back Button', () => {
     await objectivesTextarea.blur()
 
     // Select project type (Initiative = Gold tier)
-    const initiativeButton = page.getByRole('button', { name: /^Initiative/ })
+    // Use specific text to avoid matching TableSlot's "Initiative Click to add" button
+    const initiativeButton = page.getByRole('button', { name: /Initiative.*Move your life/ })
     await initiativeButton.click()
 
     await page.waitForTimeout(500)

--- a/packages/web/e2e/new-ui-workflow.spec.ts
+++ b/packages/web/e2e/new-ui-workflow.spec.ts
@@ -86,7 +86,8 @@ test.describe('New UI Workflow', () => {
     await deadlineInput.blur()
 
     // Select project type (Initiative = Gold tier)
-    const initiativeButton = page.getByRole('button', { name: /^Initiative/ })
+    // Use specific text to avoid matching TableSlot's "Initiative Click to add" button
+    const initiativeButton = page.getByRole('button', { name: /Initiative.*Move your life/ })
     await initiativeButton.click()
 
     // Wait for auto-save

--- a/packages/web/e2e/table-slot-backlog-select.spec.ts
+++ b/packages/web/e2e/table-slot-backlog-select.spec.ts
@@ -40,8 +40,8 @@ async function createProjectAndAddToSorting(page: Page, storeId: string, project
   await descriptionTextarea.fill('Test project for backlog select')
   await descriptionTextarea.blur()
 
-  // Select category
-  const categoryButton = page.getByRole('button', { name: 'Growth' })
+  // Select category (pick "Health")
+  const categoryButton = page.getByRole('button', { name: 'Health' })
   await categoryButton.click()
 
   await page.waitForTimeout(500)

--- a/packages/web/e2e/table-slot-backlog-select.spec.ts
+++ b/packages/web/e2e/table-slot-backlog-select.spec.ts
@@ -60,7 +60,8 @@ async function createProjectAndAddToSorting(page: Page, storeId: string, project
   await objectivesTextarea.blur()
 
   // Select project type (Initiative = Gold tier)
-  const initiativeButton = page.getByRole('button', { name: /^Initiative/ })
+  // Use specific text to avoid matching TableSlot's "Initiative Click to add" button
+  const initiativeButton = page.getByRole('button', { name: /Initiative.*Move your life/ })
   await initiativeButton.click()
 
   await page.waitForTimeout(500)

--- a/packages/web/e2e/table-slot-backlog-select.spec.ts
+++ b/packages/web/e2e/table-slot-backlog-select.spec.ts
@@ -74,9 +74,20 @@ async function createProjectAndAddToSorting(page: Page, storeId: string, project
   // Stage 3: Detail
   await expect(page.getByText('Stage 3: Detail')).toBeVisible({ timeout: 10000 })
 
+  // Add at least one task (required for "Add to Sorting" to be enabled)
+  const addTaskButton = page.getByRole('button', { name: '+ Add Task' })
+  await addTaskButton.click()
+  const taskModal = page.getByRole('dialog')
+  await expect(taskModal).toBeVisible({ timeout: 5000 })
+  const taskTitleInput = taskModal.locator('input[placeholder="Task title"]')
+  await taskTitleInput.fill('Test task')
+  const createTaskButton = taskModal.getByRole('button', { name: 'Create Task' })
+  await createTaskButton.click()
+  await expect(taskModal).not.toBeVisible({ timeout: 5000 })
+
   // Add to Sorting (this moves it to backlog)
   const addToSortingButton = page.getByRole('button', { name: 'Add to Sorting' })
-  await expect(addToSortingButton).toBeEnabled()
+  await expect(addToSortingButton).toBeEnabled({ timeout: 5000 })
   await addToSortingButton.click()
 
   // Wait for Sorting Room to load

--- a/packages/web/e2e/table-slot-backlog-select.spec.ts
+++ b/packages/web/e2e/table-slot-backlog-select.spec.ts
@@ -1,0 +1,199 @@
+import { test, expect, Page } from '@playwright/test'
+import { waitForLiveStoreReady, createTestUserViaAPI, loginViaUI } from './test-utils.js'
+
+const REQUIRE_AUTH = process.env.REQUIRE_AUTH === 'true'
+
+/**
+ * Helper to navigate to new UI with unique store ID
+ */
+async function navigateToNewUiWithUniqueStore(page: Page) {
+  const storeId = `test-${Date.now()}-${Math.random().toString(36).substring(7)}`
+
+  if (REQUIRE_AUTH) {
+    const testUser = await createTestUserViaAPI()
+    await page.goto(`/login?storeId=${storeId}`)
+    await loginViaUI(page, testUser.email, testUser.password, { skipNavigation: true })
+    await page.waitForLoadState('networkidle', { timeout: 15000 })
+  }
+
+  return storeId
+}
+
+/**
+ * Helper to create a project through the drafting room and add to sorting
+ */
+async function createProjectAndAddToSorting(page: Page, storeId: string, projectName: string) {
+  // Navigate to create new project
+  await page.goto(`/drafting-room/new?storeId=${storeId}`)
+  await waitForLiveStoreReady(page)
+
+  // Wait for Stage 1 form to load
+  await expect(page.getByText('Stage 1: Identify')).toBeVisible({ timeout: 10000 })
+
+  // Fill in project title
+  const titleInput = page.locator('input[placeholder*="project called"]')
+  await titleInput.fill(projectName)
+  await titleInput.blur()
+
+  // Fill in description
+  const descriptionTextarea = page.locator('textarea[placeholder*="1-2 sentences"]')
+  await descriptionTextarea.fill('Test project for backlog select')
+  await descriptionTextarea.blur()
+
+  // Select category
+  const categoryButton = page.getByRole('button', { name: 'Growth' })
+  await categoryButton.click()
+
+  await page.waitForTimeout(500)
+
+  // Continue to Stage 2
+  const continueToStage2Button = page.getByRole('button', { name: 'Continue to Stage 2' })
+  await expect(continueToStage2Button).toBeEnabled()
+  await continueToStage2Button.click()
+
+  // Stage 2: Scope
+  await expect(page.getByText('Stage 2: Scope')).toBeVisible({ timeout: 10000 })
+
+  // Fill in objectives
+  const objectivesTextarea = page.locator('textarea[placeholder*="specific outcomes"]')
+  await objectivesTextarea.fill('Test objectives')
+  await objectivesTextarea.blur()
+
+  // Select project type (Initiative = Gold tier)
+  const initiativeButton = page.getByRole('button', { name: /^Initiative/ })
+  await initiativeButton.click()
+
+  await page.waitForTimeout(500)
+
+  // Continue to Stage 3
+  const continueToStage3Button = page.getByRole('button', { name: 'Continue to Stage 3' })
+  await expect(continueToStage3Button).toBeEnabled()
+  await continueToStage3Button.click()
+
+  // Stage 3: Detail
+  await expect(page.getByText('Stage 3: Detail')).toBeVisible({ timeout: 10000 })
+
+  // Add to Sorting (this moves it to backlog)
+  const addToSortingButton = page.getByRole('button', { name: 'Add to Sorting' })
+  await expect(addToSortingButton).toBeEnabled()
+  await addToSortingButton.click()
+
+  // Wait for Sorting Room to load
+  await expect(page.getByRole('heading', { name: 'Initiative' })).toBeVisible({ timeout: 10000 })
+}
+
+test.describe('Table Slot Backlog Selection', () => {
+  test.describe.configure({ timeout: 120000 }) // 2 minute timeout
+
+  test('clicking empty Gold slot shows popover above the slot with backlog projects', async ({
+    page,
+  }) => {
+    const storeId = await navigateToNewUiWithUniqueStore(page)
+    const projectName = `Backlog Test ${Date.now()}`
+
+    // Create a project and add it to sorting (backlog)
+    await createProjectAndAddToSorting(page, storeId, projectName)
+
+    // Navigate to Life Map to see the TableBar at the bottom
+    await page.goto(`/life-map?storeId=${storeId}`)
+    await waitForLiveStoreReady(page)
+
+    // Wait for the TableBar to be visible
+    const tableBar = page.locator('.bg-white\\/95.border-t')
+    await expect(tableBar).toBeVisible({ timeout: 10000 })
+
+    // Find the Initiative slot (Gold) - it should say "Click to add"
+    const goldSlot = page.locator('button').filter({ hasText: 'Initiative' }).first()
+    await expect(goldSlot).toBeVisible()
+    await expect(goldSlot.getByText('Click to add')).toBeVisible()
+
+    // Click the empty Gold slot
+    await goldSlot.click()
+
+    // Wait for the popover to appear
+    const popover = page.locator('[data-testid="backlog-select-popover"]')
+    await expect(popover).toBeVisible({ timeout: 5000 })
+
+    // Verify the popover header is correct
+    await expect(popover.getByText('Add Initiative from Backlog')).toBeVisible()
+
+    // CRITICAL: Verify the popover is visible within the viewport (not cut off)
+    const popoverBox = await popover.boundingBox()
+    expect(popoverBox).not.toBeNull()
+
+    // The popover should be above the slot, so its bottom should be above the slot's top
+    // and it should be fully visible in the viewport
+    const viewportSize = page.viewportSize()
+    expect(viewportSize).not.toBeNull()
+
+    // Popover should be fully within the viewport
+    expect(popoverBox!.y).toBeGreaterThanOrEqual(0) // Top edge should be at or below viewport top
+    expect(popoverBox!.y + popoverBox!.height).toBeLessThanOrEqual(viewportSize!.height) // Bottom edge should be within viewport
+
+    // Verify our project is listed in the popover
+    await expect(popover.getByText(projectName)).toBeVisible()
+
+    // Click the project to select it
+    await popover.getByText(projectName).click()
+
+    // Popover should close
+    await expect(popover).not.toBeVisible({ timeout: 5000 })
+
+    // The Gold slot should now show the project name (not "Click to add")
+    await expect(goldSlot.getByText('Click to add')).not.toBeVisible({ timeout: 5000 })
+    await expect(page.getByText(projectName)).toBeVisible()
+  })
+
+  test('popover closes when pressing Escape', async ({ page }) => {
+    const storeId = await navigateToNewUiWithUniqueStore(page)
+    const projectName = `Escape Test ${Date.now()}`
+
+    await createProjectAndAddToSorting(page, storeId, projectName)
+
+    await page.goto(`/life-map?storeId=${storeId}`)
+    await waitForLiveStoreReady(page)
+
+    // Click the empty Gold slot
+    const goldSlot = page.locator('button').filter({ hasText: 'Initiative' }).first()
+    await goldSlot.click()
+
+    // Verify popover is open
+    const popover = page.locator('[data-testid="backlog-select-popover"]')
+    await expect(popover).toBeVisible({ timeout: 5000 })
+
+    // Press Escape
+    await page.keyboard.press('Escape')
+
+    // Popover should close
+    await expect(popover).not.toBeVisible({ timeout: 5000 })
+  })
+
+  test('popover shows empty state with link to Drafting Room when no backlog projects', async ({
+    page,
+  }) => {
+    const storeId = await navigateToNewUiWithUniqueStore(page)
+
+    // Navigate directly to Life Map without creating any projects
+    await page.goto(`/life-map?storeId=${storeId}`)
+    await waitForLiveStoreReady(page)
+
+    // Click the empty Gold slot
+    const goldSlot = page.locator('button').filter({ hasText: 'Initiative' }).first()
+
+    // The slot might not be clickable if there's no backlog items AND no handler
+    // But with our implementation, it should still show "Click to add" and be interactive
+    if (await goldSlot.getByText('Click to add').isVisible({ timeout: 3000 })) {
+      await goldSlot.click()
+
+      // Verify popover shows empty state
+      const popover = page.locator('[data-testid="backlog-select-popover"]')
+      await expect(popover).toBeVisible({ timeout: 5000 })
+      await expect(popover.getByText('No projects available')).toBeVisible()
+      await expect(popover.getByText('Create new project')).toBeVisible()
+
+      // The "Create new project" link should navigate to drafting room
+      const createLink = popover.getByRole('link', { name: 'Create new project' })
+      await expect(createLink).toHaveAttribute('href', /\/drafting-room\/new/)
+    }
+  })
+})

--- a/packages/web/src/components/new/layout/BacklogSelectPopover.stories.tsx
+++ b/packages/web/src/components/new/layout/BacklogSelectPopover.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import React, { useState } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { BacklogSelectPopover, type BacklogItem } from './BacklogSelectPopover.js'
+
+const sampleGoldItems: BacklogItem[] = [
+  { id: '1', name: 'Launch new product line', meta: 'growth' },
+  { id: '2', name: 'Expand to European market', meta: 'growth' },
+  { id: '3', name: 'Build mobile app', meta: 'technology' },
+]
+
+const sampleSilverItems: BacklogItem[] = [
+  { id: '1', name: 'Improve CI/CD pipeline', meta: 'technology' },
+  { id: '2', name: 'Automate onboarding flow', meta: 'operations' },
+  { id: '3', name: 'Optimize database queries', meta: 'technology' },
+  { id: '4', name: 'Set up monitoring alerts', meta: 'technology' },
+  { id: '5', name: 'Refactor authentication module', meta: 'technology' },
+]
+
+// Interactive wrapper that manages popover state
+function PopoverWrapper({ stream, items }: { stream: 'gold' | 'silver'; items: BacklogItem[] }) {
+  const [isOpen, setIsOpen] = useState(true)
+  const [selected, setSelected] = useState<string | null>(null)
+
+  return (
+    <MemoryRouter>
+      <div className='relative w-[280px] p-4 bg-gray-50'>
+        <button
+          type='button'
+          onClick={() => setIsOpen(true)}
+          className='w-full p-3 border border-[#e8e4de] rounded-xl bg-white text-left'
+        >
+          <div className='text-sm text-[#8b8680]'>
+            {selected ? `Selected: ${selected}` : 'Click to open popover'}
+          </div>
+        </button>
+        <BacklogSelectPopover
+          stream={stream}
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          onSelect={id => {
+            setSelected(id)
+            setIsOpen(false)
+          }}
+          items={items}
+        />
+      </div>
+    </MemoryRouter>
+  )
+}
+
+const meta: Meta<typeof PopoverWrapper> = {
+  title: 'New UI/Layout/BacklogSelectPopover',
+  component: PopoverWrapper,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A popover for selecting backlog projects to activate on The Table. Used in empty Gold and Silver slots.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const GoldWithItems: Story = {
+  args: {
+    stream: 'gold',
+    items: sampleGoldItems,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Gold stream popover with available initiative projects.',
+      },
+    },
+  },
+}
+
+export const SilverWithItems: Story = {
+  args: {
+    stream: 'silver',
+    items: sampleSilverItems,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Silver stream popover with available optimization projects.',
+      },
+    },
+  },
+}
+
+export const EmptyState: Story = {
+  args: {
+    stream: 'gold',
+    items: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Empty state when no backlog projects are available. Shows a link to create a new project.',
+      },
+    },
+  },
+}
+
+export const ManyItems: Story = {
+  args: {
+    stream: 'silver',
+    items: [
+      ...sampleSilverItems,
+      { id: '6', name: 'Implement rate limiting', meta: 'technology' },
+      { id: '7', name: 'Add logging infrastructure', meta: 'technology' },
+      { id: '8', name: 'Create admin dashboard', meta: 'operations' },
+      { id: '9', name: 'Set up A/B testing framework', meta: 'growth' },
+      { id: '10', name: 'Migrate to new hosting provider', meta: 'technology' },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Popover with many items shows scrolling behavior.',
+      },
+    },
+  },
+}

--- a/packages/web/src/components/new/layout/BacklogSelectPopover.stories.tsx
+++ b/packages/web/src/components/new/layout/BacklogSelectPopover.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useState } from 'react'
-import { MemoryRouter } from 'react-router-dom'
 import { BacklogSelectPopover, type BacklogItem } from './BacklogSelectPopover.js'
 
 const sampleGoldItems: BacklogItem[] = [
@@ -18,34 +17,33 @@ const sampleSilverItems: BacklogItem[] = [
 ]
 
 // Interactive wrapper that manages popover state
+// Note: Router is provided by Storybook's preview.tsx (BrowserRouter)
 function PopoverWrapper({ stream, items }: { stream: 'gold' | 'silver'; items: BacklogItem[] }) {
   const [isOpen, setIsOpen] = useState(true)
   const [selected, setSelected] = useState<string | null>(null)
 
   return (
-    <MemoryRouter>
-      <div className='relative w-[280px] p-4 bg-gray-50'>
-        <button
-          type='button'
-          onClick={() => setIsOpen(true)}
-          className='w-full p-3 border border-[#e8e4de] rounded-xl bg-white text-left'
-        >
-          <div className='text-sm text-[#8b8680]'>
-            {selected ? `Selected: ${selected}` : 'Click to open popover'}
-          </div>
-        </button>
-        <BacklogSelectPopover
-          stream={stream}
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          onSelect={id => {
-            setSelected(id)
-            setIsOpen(false)
-          }}
-          items={items}
-        />
-      </div>
-    </MemoryRouter>
+    <div className='relative w-[280px] p-4 bg-gray-50'>
+      <button
+        type='button'
+        onClick={() => setIsOpen(true)}
+        className='w-full p-3 border border-[#e8e4de] rounded-xl bg-white text-left'
+      >
+        <div className='text-sm text-[#8b8680]'>
+          {selected ? `Selected: ${selected}` : 'Click to open popover'}
+        </div>
+      </button>
+      <BacklogSelectPopover
+        stream={stream}
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onSelect={id => {
+          setSelected(id)
+          setIsOpen(false)
+        }}
+        items={items}
+      />
+    </div>
   )
 }
 

--- a/packages/web/src/components/new/layout/BacklogSelectPopover.tsx
+++ b/packages/web/src/components/new/layout/BacklogSelectPopover.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { generateRoute } from '../../../constants/routes.js'
+import { preserveStoreIdInUrl } from '../../../utils/navigation.js'
+
+export type BacklogStream = 'gold' | 'silver'
+
+export interface BacklogItem {
+  id: string
+  name: string
+  meta?: string
+}
+
+export interface BacklogSelectPopoverProps {
+  stream: BacklogStream
+  isOpen: boolean
+  onClose: () => void
+  onSelect: (id: string) => void
+  items: BacklogItem[]
+}
+
+const streamColors: Record<BacklogStream, string> = {
+  gold: '#d8a650',
+  silver: '#c5ced8',
+}
+
+const streamLabels: Record<BacklogStream, string> = {
+  gold: 'Initiative',
+  silver: 'Optimization',
+}
+
+/**
+ * BacklogSelectPopover - A popover for selecting a backlog project to activate on the Table.
+ * Shows available projects for the given stream (Gold or Silver).
+ */
+export const BacklogSelectPopover: React.FC<BacklogSelectPopoverProps> = ({
+  stream,
+  isOpen,
+  onClose,
+  onSelect,
+  items,
+}) => {
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  // Handle click outside and escape key
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const handleItemClick = (id: string) => {
+    onSelect(id)
+    onClose()
+  }
+
+  return (
+    <div
+      ref={popoverRef}
+      data-testid='backlog-select-popover'
+      className='absolute left-0 right-0 bottom-full mb-2 z-50 bg-white rounded-xl border border-[#e8e4de] shadow-lg overflow-hidden'
+      style={{ borderBottomColor: streamColors[stream], borderBottomWidth: '3px' }}
+    >
+      <div className='px-3 py-2 border-b border-[#e8e4de]'>
+        <h5 className='text-sm font-medium text-[#2f2b27]'>
+          Add {streamLabels[stream]} from Backlog
+        </h5>
+      </div>
+
+      {items.length === 0 ? (
+        <div className='px-3 py-4 text-center'>
+          <p className='text-sm text-[#8b8680] mb-2'>No projects available</p>
+          <Link
+            to={preserveStoreIdInUrl(generateRoute.projectCreate())}
+            className='text-sm text-[#2f2b27] underline hover:no-underline'
+            onClick={onClose}
+          >
+            Create new project
+          </Link>
+        </div>
+      ) : (
+        <ul className='max-h-[240px] overflow-y-auto'>
+          {items.map(item => (
+            <li key={item.id}>
+              <button
+                type='button'
+                onClick={() => handleItemClick(item.id)}
+                className='w-full text-left px-3 py-2 hover:bg-[#faf9f7] transition-colors border-l-2 border-transparent hover:border-current'
+                style={
+                  {
+                    '--tw-border-opacity': 1,
+                    borderLeftColor: 'transparent',
+                  } as React.CSSProperties
+                }
+                onMouseEnter={e => {
+                  e.currentTarget.style.borderLeftColor = streamColors[stream]
+                }}
+                onMouseLeave={e => {
+                  e.currentTarget.style.borderLeftColor = 'transparent'
+                }}
+              >
+                <div className='font-medium text-[#2f2b27] text-sm'>{item.name}</div>
+                {item.meta && <div className='text-xs text-[#8b8680]'>{item.meta}</div>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/packages/web/src/components/new/layout/TableBar.test.tsx
+++ b/packages/web/src/components/new/layout/TableBar.test.tsx
@@ -6,13 +6,27 @@ import type { TableBronzeProjectEntry } from '@lifebuild/shared/schema'
 import { TableBar } from './TableBar.js'
 
 let mockProjects = [] as ReturnType<typeof createMockProject>[]
-let mockTableState: { configuration: null; tabledBronzeProjects: TableBronzeProjectEntry[] } = {
+let mockTableState: {
+  configuration: null
+  tabledBronzeProjects: TableBronzeProjectEntry[]
+  initializeConfiguration: () => Promise<void>
+  assignGold: () => Promise<void>
+  assignSilver: () => Promise<void>
+} = {
   configuration: null,
   tabledBronzeProjects: [],
+  initializeConfiguration: vi.fn(),
+  assignGold: vi.fn(),
+  assignSilver: vi.fn(),
 }
 
 vi.mock('../../../livestore-compat.js', () => ({
   useQuery: () => mockProjects,
+  useStore: () => ({ store: { commit: vi.fn() } }),
+}))
+
+vi.mock('../../../contexts/AuthContext.js', () => ({
+  useAuth: () => ({ user: { id: 'test-user' } }),
 }))
 
 vi.mock('../../../hooks/useTableState.js', () => ({
@@ -22,7 +36,13 @@ vi.mock('../../../hooks/useTableState.js', () => ({
 describe('TableBar', () => {
   beforeEach(() => {
     mockProjects = []
-    mockTableState = { configuration: null, tabledBronzeProjects: [] }
+    mockTableState = {
+      configuration: null,
+      tabledBronzeProjects: [],
+      initializeConfiguration: vi.fn(),
+      assignGold: vi.fn(),
+      assignSilver: vi.fn(),
+    }
   })
 
   it('shows the top tabled bronze project and count', () => {
@@ -60,6 +80,9 @@ describe('TableBar', () => {
           removedAt: null,
         },
       ],
+      initializeConfiguration: vi.fn(),
+      assignGold: vi.fn(),
+      assignSilver: vi.fn(),
     }
 
     render(
@@ -107,6 +130,9 @@ describe('TableBar', () => {
           removedAt: null,
         },
       ],
+      initializeConfiguration: vi.fn(),
+      assignGold: vi.fn(),
+      assignSilver: vi.fn(),
     }
 
     render(

--- a/packages/web/src/components/new/layout/TableBar.tsx
+++ b/packages/web/src/components/new/layout/TableBar.tsx
@@ -1,16 +1,29 @@
-import React, { useMemo } from 'react'
-import { useQuery } from '../../../livestore-compat.js'
+import React, { useMemo, useCallback } from 'react'
+import { useQuery, useStore } from '../../../livestore-compat.js'
 import { getProjects$ } from '@lifebuild/shared/queries'
+import { resolveLifecycleState, type ProjectLifecycleState } from '@lifebuild/shared'
+import type { Project } from '@lifebuild/shared/schema'
+import { events } from '@lifebuild/shared/schema'
 import { useTableState } from '../../../hooks/useTableState.js'
+import { useAuth } from '../../../contexts/AuthContext.js'
 import { TableSlot } from './TableSlot.js'
+
+function getLifecycleState(project: Project): ProjectLifecycleState {
+  return resolveLifecycleState(project.projectLifecycleState, null)
+}
 
 /**
  * TableBar component - The persistent bottom bar showing The Table (Gold, Silver, Bronze streams).
  * This shows the top priority projects across the three work streams.
+ * Empty Gold/Silver slots are clickable to select from backlog.
  */
 export const TableBar: React.FC = () => {
   const allProjects = useQuery(getProjects$) ?? []
-  const { configuration, tabledBronzeProjects } = useTableState()
+  const { configuration, tabledBronzeProjects, initializeConfiguration, assignGold, assignSilver } =
+    useTableState()
+  const { store } = useStore()
+  const { user } = useAuth()
+  const actorId = user?.id
 
   // Get Gold project details
   const goldProject = useMemo(
@@ -39,6 +52,109 @@ export const TableBar: React.FC = () => {
     [tabledBronzeProjects, allProjects]
   )
 
+  // Filter backlog projects by stream (Stage 4, backlog status)
+  const goldBacklog = useMemo(
+    () =>
+      allProjects
+        .filter(p => {
+          const lifecycle = getLifecycleState(p)
+          return (
+            lifecycle.status === 'backlog' &&
+            lifecycle.stage === 4 &&
+            lifecycle.stream === 'gold' &&
+            p.id !== configuration?.goldProjectId
+          )
+        })
+        .sort((a, b) => {
+          const aPos = getLifecycleState(a).queuePosition ?? 999
+          const bPos = getLifecycleState(b).queuePosition ?? 999
+          return aPos - bPos
+        }),
+    [allProjects, configuration?.goldProjectId]
+  )
+
+  const silverBacklog = useMemo(
+    () =>
+      allProjects
+        .filter(p => {
+          const lifecycle = getLifecycleState(p)
+          return (
+            lifecycle.status === 'backlog' &&
+            lifecycle.stage === 4 &&
+            lifecycle.stream === 'silver' &&
+            p.id !== configuration?.silverProjectId
+          )
+        })
+        .sort((a, b) => {
+          const aPos = getLifecycleState(a).queuePosition ?? 999
+          const bPos = getLifecycleState(b).queuePosition ?? 999
+          return aPos - bPos
+        }),
+    [allProjects, configuration?.silverProjectId]
+  )
+
+  // Handler for activating a gold project from backlog
+  const handleActivateGold = useCallback(
+    async (projectId: string) => {
+      const project = allProjects.find(p => p.id === projectId)
+      if (!project) return
+
+      // Update project lifecycle to active with gold slot
+      const currentLifecycle = getLifecycleState(project)
+      store.commit(
+        events.projectLifecycleUpdated({
+          projectId: project.id,
+          lifecycleState: {
+            ...currentLifecycle,
+            status: 'active',
+            slot: 'gold',
+          },
+          updatedAt: new Date(),
+          actorId,
+        })
+      )
+
+      // Initialize configuration if it doesn't exist, otherwise assign
+      if (!configuration) {
+        await initializeConfiguration({ goldProjectId: project.id })
+      } else {
+        await assignGold(project.id)
+      }
+    },
+    [allProjects, store, actorId, configuration, initializeConfiguration, assignGold]
+  )
+
+  // Handler for activating a silver project from backlog
+  const handleActivateSilver = useCallback(
+    async (projectId: string) => {
+      const project = allProjects.find(p => p.id === projectId)
+      if (!project) return
+
+      // Update project lifecycle to active with silver slot
+      const currentLifecycle = getLifecycleState(project)
+      store.commit(
+        events.projectLifecycleUpdated({
+          projectId: project.id,
+          lifecycleState: {
+            ...currentLifecycle,
+            status: 'active',
+            slot: 'silver',
+          },
+          updatedAt: new Date(),
+          actorId,
+        })
+      )
+
+      // Initialize configuration if it doesn't exist, otherwise assign
+      if (!configuration) {
+        await initializeConfiguration({ silverProjectId: project.id })
+      } else {
+        await assignSilver(project.id)
+      }
+    },
+    [allProjects, store, actorId, configuration, initializeConfiguration, assignSilver]
+  )
+
   return (
     <div className='bg-white/95 border-t border-[#e8e4de] shadow-[0_-12px_24px_rgba(0,0,0,0.06)] py-3.5 px-6 flex-shrink-0'>
       <div className='grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3 items-center'>
@@ -47,12 +163,24 @@ export const TableBar: React.FC = () => {
           projectId={goldProject?.id}
           projectName={goldProject?.name}
           projectMeta={goldProject?.category ?? undefined}
+          backlogItems={goldBacklog.map(p => ({
+            id: p.id,
+            name: p.name,
+            meta: p.category ?? undefined,
+          }))}
+          onSelectFromBacklog={handleActivateGold}
         />
         <TableSlot
           stream='silver'
           projectId={silverProject?.id}
           projectName={silverProject?.name}
           projectMeta={silverProject?.category ?? undefined}
+          backlogItems={silverBacklog.map(p => ({
+            id: p.id,
+            name: p.name,
+            meta: p.category ?? undefined,
+          }))}
+          onSelectFromBacklog={handleActivateSilver}
         />
         <TableSlot
           stream='bronze'

--- a/packages/web/src/components/new/layout/TableSlot.stories.tsx
+++ b/packages/web/src/components/new/layout/TableSlot.stories.tsx
@@ -1,0 +1,190 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import React, { useState } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { TableSlot, type Stream } from './TableSlot.js'
+import type { BacklogItem } from './BacklogSelectPopover.js'
+
+const sampleGoldBacklog: BacklogItem[] = [
+  { id: '1', name: 'Launch new product line', meta: 'growth' },
+  { id: '2', name: 'Expand to European market', meta: 'growth' },
+]
+
+const sampleSilverBacklog: BacklogItem[] = [
+  { id: '1', name: 'Improve CI/CD pipeline', meta: 'technology' },
+  { id: '2', name: 'Automate onboarding flow', meta: 'operations' },
+]
+
+// Interactive wrapper for slots with backlog selection
+function InteractiveSlot({
+  stream,
+  backlogItems,
+}: {
+  stream: Stream
+  backlogItems?: BacklogItem[]
+}) {
+  const [selectedProject, setSelectedProject] = useState<{
+    id: string
+    name: string
+    meta?: string
+  } | null>(null)
+
+  return (
+    <MemoryRouter>
+      <div className='w-[280px]'>
+        <TableSlot
+          stream={stream}
+          projectId={selectedProject?.id}
+          projectName={selectedProject?.name}
+          projectMeta={selectedProject?.meta}
+          backlogItems={backlogItems}
+          onSelectFromBacklog={id => {
+            const item = backlogItems?.find(i => i.id === id)
+            if (item) {
+              setSelectedProject({ id: item.id, name: item.name, meta: item.meta })
+            }
+          }}
+        />
+      </div>
+    </MemoryRouter>
+  )
+}
+
+const meta: Meta<typeof TableSlot> = {
+  title: 'New UI/Layout/TableSlot',
+  component: TableSlot,
+  decorators: [
+    Story => (
+      <MemoryRouter>
+        <div className='w-[280px]'>
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A single slot in The Table showing Gold, Silver, or Bronze stream. Empty Gold/Silver slots can be clicked to select from backlog.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof TableSlot>
+
+export const GoldFilled: Story = {
+  args: {
+    stream: 'gold',
+    projectId: 'project-1',
+    projectName: 'Launch Mobile App',
+    projectMeta: 'growth',
+    progress: 0.65,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A Gold slot with an active initiative project showing progress.',
+      },
+    },
+  },
+}
+
+export const SilverFilled: Story = {
+  args: {
+    stream: 'silver',
+    projectId: 'project-2',
+    projectName: 'Improve CI/CD Pipeline',
+    projectMeta: 'technology',
+    progress: 0.3,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A Silver slot with an active optimization project showing progress.',
+      },
+    },
+  },
+}
+
+export const BronzeFilled: Story = {
+  args: {
+    stream: 'bronze',
+    projectId: 'project-3',
+    projectName: 'Quick Task Project',
+    projectMeta: 'home',
+    bronzeCount: 3,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A Bronze slot showing the top project with additional count.',
+      },
+    },
+  },
+}
+
+export const GoldEmpty: Story = {
+  args: {
+    stream: 'gold',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'An empty Gold slot without backlog selection enabled.',
+      },
+    },
+  },
+}
+
+export const BronzeEmpty: Story = {
+  args: {
+    stream: 'bronze',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'An empty Bronze slot. Bronze slots do not support inline backlog selection.',
+      },
+    },
+  },
+}
+
+export const GoldEmptyWithBacklog: StoryObj<typeof InteractiveSlot> = {
+  render: () => <InteractiveSlot stream='gold' backlogItems={sampleGoldBacklog} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An empty Gold slot with backlog selection. Click to see available initiatives and select one.',
+      },
+    },
+  },
+}
+
+export const SilverEmptyWithBacklog: StoryObj<typeof InteractiveSlot> = {
+  render: () => <InteractiveSlot stream='silver' backlogItems={sampleSilverBacklog} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An empty Silver slot with backlog selection. Click to see available optimizations and select one.',
+      },
+    },
+  },
+}
+
+export const GoldEmptyNoBacklog: StoryObj<typeof InteractiveSlot> = {
+  render: () => <InteractiveSlot stream='gold' backlogItems={[]} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An empty Gold slot when no backlog projects are available. Shows empty state with link to create project.',
+      },
+    },
+  },
+}

--- a/packages/web/src/components/new/layout/TableSlot.stories.tsx
+++ b/packages/web/src/components/new/layout/TableSlot.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useState } from 'react'
-import { MemoryRouter } from 'react-router-dom'
 import { TableSlot, type Stream } from './TableSlot.js'
 import type { BacklogItem } from './BacklogSelectPopover.js'
 
@@ -15,6 +14,7 @@ const sampleSilverBacklog: BacklogItem[] = [
 ]
 
 // Interactive wrapper for slots with backlog selection
+// Note: Router is provided by Storybook's preview.tsx (BrowserRouter)
 function InteractiveSlot({
   stream,
   backlogItems,
@@ -29,23 +29,21 @@ function InteractiveSlot({
   } | null>(null)
 
   return (
-    <MemoryRouter>
-      <div className='w-[280px]'>
-        <TableSlot
-          stream={stream}
-          projectId={selectedProject?.id}
-          projectName={selectedProject?.name}
-          projectMeta={selectedProject?.meta}
-          backlogItems={backlogItems}
-          onSelectFromBacklog={id => {
-            const item = backlogItems?.find(i => i.id === id)
-            if (item) {
-              setSelectedProject({ id: item.id, name: item.name, meta: item.meta })
-            }
-          }}
-        />
-      </div>
-    </MemoryRouter>
+    <div className='w-[280px]'>
+      <TableSlot
+        stream={stream}
+        projectId={selectedProject?.id}
+        projectName={selectedProject?.name}
+        projectMeta={selectedProject?.meta}
+        backlogItems={backlogItems}
+        onSelectFromBacklog={id => {
+          const item = backlogItems?.find(i => i.id === id)
+          if (item) {
+            setSelectedProject({ id: item.id, name: item.name, meta: item.meta })
+          }
+        }}
+      />
+    </div>
   )
 }
 
@@ -54,11 +52,9 @@ const meta: Meta<typeof TableSlot> = {
   component: TableSlot,
   decorators: [
     Story => (
-      <MemoryRouter>
-        <div className='w-[280px]'>
-          <Story />
-        </div>
-      </MemoryRouter>
+      <div className='w-[280px]'>
+        <Story />
+      </div>
     ),
   ],
   parameters: {


### PR DESCRIPTION
## Summary

Add popover to empty Gold and Silver table slots that shows available backlog projects. When users click an empty slot, a popover appears above the slot showing projects from that stream's backlog. Selecting a project activates it on the table. Fixes positioning to prevent popover from appearing off-screen below the TableBar.

## Changelog

- Add "Add from backlog" popover to empty Gold/Silver table slots
- Popover positioned above slot to stay within viewport
- E2E test verifies popover visibility and functionality

## Test Plan

Unit tests pass: `pnpm test`
Lint passes: `pnpm lint-all`
E2E test included: `packages/web/e2e/table-slot-backlog-select.spec.ts`
- Verifies popover appears above the slot
- Checks popover content is visible within viewport
- Tests popover closes on Escape key
- Tests empty state shows link to create new project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new UI interaction that commits lifecycle/table configuration events from the persistent `TableBar`, so regressions could incorrectly activate projects or mis-handle initialization; mitigated by added unit/E2E coverage.
> 
> **Overview**
> Makes empty **Gold/Silver Table slots** actionable by opening a new `BacklogSelectPopover` positioned above the slot; it lists backlog projects for that stream, supports outside-click/Escape dismissal, and links to create a project when empty.
> 
> Updates `TableBar`/`TableSlot` to compute stream-specific backlog candidates (stage 4, `backlog`), render “Click to add”, and on selection commit `projectLifecycleUpdated` + initialize/assign the table configuration (`initializeConfiguration`, `assignGold`, `assignSilver`). Adds Storybook stories and a new Playwright E2E spec covering popover visibility/viewport fit, selection, Escape close, and empty-state behavior; tweaks existing E2E selectors to avoid ambiguous “Initiative” matches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0469ac701444d740615382da6c94b4c83a0ff95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->