### PR TITLE
fix(web): update Activate buttons to Activate to Table

### DIFF
--- a/packages/web/src/components/life-category/LifeCategoryPresenter.tsx
+++ b/packages/web/src/components/life-category/LifeCategoryPresenter.tsx
@@ -122,7 +122,7 @@ const SortableBacklogProject: React.FC<SortableBacklogProjectProps> = ({
             disabled={isActivationInProgress}
             className='px-3 py-1.5 text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-green-500 disabled:opacity-60 disabled:cursor-not-allowed'
           >
-            {isActivatingThisProject ? 'Activating...' : 'Activate'}
+            {isActivatingThisProject ? 'Activating...' : 'Activate to Table'}
           </button>
         </div>
       </div>

--- a/packages/web/src/components/new/sorting-room/TableConfirmDialog.tsx
+++ b/packages/web/src/components/new/sorting-room/TableConfirmDialog.tsx
@@ -142,7 +142,7 @@ export const TableConfirmDialog: React.FC<TableConfirmDialogProps> = ({
               className='py-2 px-5 rounded-lg text-sm font-medium bg-[#2f2b27] text-white border-none cursor-pointer transition-all duration-150 hover:bg-black'
               onClick={onConfirm}
             >
-              {mode === 'activate' ? 'Activate' : 'Release'}
+              {mode === 'activate' ? 'Activate to Table' : 'Release'}
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary

Fixes label mismatch between documentation (Quickstart Guide Section 3.3) and UI.

## Changes

Updates "Activate" button text to "Activate to Table" in two locations:
- **TableConfirmDialog** - confirmation dialog button
- **LifeCategoryPresenter** - life category view button

This matches the existing label in SortableProjectCard and aligns with documentation.

## Changelog

- Fixed "Activate" button labels to say "Activate to Table" for consistency

Closes #486