### PR TITLE
fix(web): improve visibility of backlog count badges

### DIFF
--- a/packages/web/src/components/new/life-map/CategoryCard.tsx
+++ b/packages/web/src/components/new/life-map/CategoryCard.tsx
@@ -126,23 +126,29 @@ export const CategoryCard: React.FC<CategoryCardProps> = ({
 
       {/* Planning and Backlog links */}
       {(planningCount > 0 || backlogCount > 0) && (
-        <div className='mt-2 flex gap-2 flex-wrap'>
+        <div className='mt-3 flex gap-2 flex-wrap'>
           {planningCount > 0 && (
             <Link
               to={preserveStoreIdInUrl(`${generateRoute.draftingRoom()}?category=${categoryValue}`)}
-              className='no-underline text-[10px] font-semibold text-[#8b8680] uppercase tracking-wide hover:text-[#2f2b27]'
+              className='no-underline inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-[#f5f3f0] hover:bg-[#ebe8e3] transition-colors duration-150'
               onClick={e => e.stopPropagation()}
             >
-              DRAFTING ({planningCount})
+              <span className='text-xs font-medium text-[#8b8680]'>Drafting</span>
+              <span className='text-xs font-semibold text-[#2f2b27] bg-white px-1.5 py-0.5 rounded-full min-w-[1.25rem] text-center'>
+                {planningCount}
+              </span>
             </Link>
           )}
           {backlogCount > 0 && (
             <Link
               to={preserveStoreIdInUrl(`${generateRoute.sortingRoom()}?category=${categoryValue}`)}
-              className='no-underline text-[10px] font-semibold text-[#8b8680] uppercase tracking-wide hover:text-[#2f2b27]'
+              className='no-underline inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-[#f5f3f0] hover:bg-[#ebe8e3] transition-colors duration-150'
               onClick={e => e.stopPropagation()}
             >
-              SORTING ({backlogCount})
+              <span className='text-xs font-medium text-[#8b8680]'>Sorting</span>
+              <span className='text-xs font-semibold text-[#2f2b27] bg-white px-1.5 py-0.5 rounded-full min-w-[1.25rem] text-center'>
+                {backlogCount}
+              </span>
             </Link>
           )}
         </div>


### PR DESCRIPTION
## Summary

Fixes the "tiny writing" issue with backlog counts in CategoryCard. The counts are now much more scannable.

## Before/After

**Before:** `SORTING (3)` in 10px gray uppercase text
**After:** Pill badges with white count numbers - easier to scan at a glance

## Changes

- Increased font size from 10px to 12px (text-xs)
- Added pill/badge styling with rounded backgrounds
- Count numbers displayed in white badges for visual weight
- Changed from ALL CAPS to Title Case for readability
- Added hover states for better interactivity

## Changelog

- Improved visibility of planning/backlog count badges in life map categories

Closes #484