### PR TITLE
fix(web): update Stage 1 Exit button to Save & Exit

### DIFF
--- a/packages/web/src/components/new/drafting-room/Stage1Form.tsx
+++ b/packages/web/src/components/new/drafting-room/Stage1Form.tsx
@@ -235,7 +235,7 @@ export const Stage1Form: React.FC = () => {
             className='flex-1 py-2.5 px-4 rounded-lg text-sm font-medium bg-transparent border border-[#e8e4de] text-[#8b8680] cursor-pointer transition-all duration-200 hover:border-[#d0ccc5] hover:text-[#2f2b27]'
             onClick={handleExit}
           >
-            Exit
+            Save & Exit
           </button>
           <button
             type='button'


### PR DESCRIPTION
## Summary

Updates the Drafting Room Stage 1 "Exit" button to say "Save & Exit" for consistency with Stage 2 and Stage 3.

## Rationale

The button already saves the project before exiting, so the label should reflect that behavior. This matches user expectations and is consistent with the other stages.

## Changelog

- Updated Stage 1 Exit button label to "Save & Exit"

Closes #374