### PR TITLE
feat(web): add The Table label to TableBar

### DIFF
--- a/packages/web/src/components/new/layout/TableBar.tsx
+++ b/packages/web/src/components/new/layout/TableBar.tsx
@@ -40,7 +40,10 @@ export const TableBar: React.FC = () => {
   )
 
   return (
-    <div className='bg-white/95 border-t border-[#e8e4de] shadow-[0_-12px_24px_rgba(0,0,0,0.06)] py-3.5 px-6 flex-shrink-0'>
+    <div className='bg-white/95 border-t border-[#e8e4de] shadow-[0_-12px_24px_rgba(0,0,0,0.06)] py-3 px-6 flex-shrink-0'>
+      <div className='text-[10px] font-semibold text-[#8b8680] uppercase tracking-wider mb-2'>
+        The Table
+      </div>
       <div className='grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3 items-center'>
         <TableSlot
           stream='gold'


### PR DESCRIPTION
## Summary

Adds THE TABLE label above the three slots in the TableBar to make it clear this is the focal point for active work.

## Context

From the Quickstart Guide: Active projects in lifebuild live On the Table - but this was not labeled in the UI.

## Changes

- Added small uppercase THE TABLE label above the Initiative/Optimization/To-Do slots
- Slightly reduced vertical padding to maintain visual balance

## Changelog

- Added The Table header label to the bottom TableBar

Closes #469