### PR TITLE
Prevent duplicate terminal LLM responses

### DIFF
--- a/packages/server/src/services/event-processor.ts
+++ b/packages/server/src/services/event-processor.ts
@@ -1492,6 +1492,7 @@ export class EventProcessor {
     let promptErrorCaptured = false
     let iterationCount = 0
     let assistantResponseEmitted = false
+    let anyResponseEmitted = false
     let failureContext: Record<string, unknown> | undefined
     let latestAssistantText = ''
     let assistantMessageEventCount = 0
@@ -1531,6 +1532,7 @@ export class EventProcessor {
                 },
               })
             )
+            anyResponseEmitted = true
           }
           break
         }
@@ -1650,6 +1652,7 @@ export class EventProcessor {
         })
       )
       assistantResponseEmitted = true
+      anyResponseEmitted = true
     }
 
     if (sawError && !assistantResponseEmitted) {
@@ -1657,6 +1660,11 @@ export class EventProcessor {
         logger.info(
           { storeId, conversationId, userMessageId: userMessage.id },
           'Skipping fallback error response because store is stopping'
+        )
+      } else if (anyResponseEmitted) {
+        logger.info(
+          { storeId, conversationId, userMessageId: userMessage.id },
+          'Skipping fallback error response because a response was already emitted'
         )
       } else {
         logger.warn(
@@ -1682,6 +1690,7 @@ export class EventProcessor {
           })
         )
         assistantResponseEmitted = true
+        anyResponseEmitted = true
       }
     }
 


### PR DESCRIPTION
## Summary
- prevent a second fallback error reply when Pi already emitted a response for the same prompt
- add regression coverage for tool-error + assistant-error flows to assert a single terminal reply
- extend stub responder/fullstack integration test to support deterministic fatal errors and assert exactly one assistant response per user message

## Changelog
- Fix duplicate assistant error responses for single user prompts in server-side Pi processing
- Add end-to-end assertion coverage for one-response-per-message behavior

Supersedes #619.