### PR TITLE
Add GitHub repo link and live demo URL to hex-grid-prototype

### DIFF
--- a/packages/hex-grid-prototype/README.md
+++ b/packages/hex-grid-prototype/README.md
@@ -38,6 +38,10 @@ pnpm lint-all     # Lint, format, and typecheck
 pnpm deploy       # Deploy to Cloudflare Pages
 ```
 
+## Live Demo
+
+https://hex-grid-prototype.pages.dev/
+
 ## Deploy
 
 Deploys as a static site to Cloudflare Pages:

--- a/packages/hex-grid-prototype/src/App.tsx
+++ b/packages/hex-grid-prototype/src/App.tsx
@@ -648,6 +648,28 @@ export function App() {
         {mode === 'parchment' ? 'Parchment' : 'Kubelka-Munk'} [Tab]
       </div>
 
+      {/* GitHub repo link */}
+      <a
+        href='https://github.com/sociotechnica-org/lifebuild/tree/main/packages/hex-grid-prototype'
+        target='_blank'
+        rel='noopener noreferrer'
+        style={{
+          position: 'absolute',
+          bottom: 16,
+          right: 16,
+          color: '#5c4a32',
+          fontFamily: 'monospace',
+          fontSize: 11,
+          background: 'rgba(232, 213, 181, 0.85)',
+          padding: '4px 8px',
+          borderRadius: 4,
+          border: '1px solid #c4a87a',
+          textDecoration: 'none',
+        }}
+      >
+        GitHub
+      </a>
+
       <div style={{ position: 'absolute', top: 16, left: 16 }}>
         {panelOpen && (
           <div style={panelBodyStyle}>


### PR DESCRIPTION
## Summary

Add a clickable GitHub repository link in the bottom-right corner of the hex grid prototype UI and include the live demo domain in the README.

## Changelog

- Add GitHub repo link to hex-grid-prototype UI
- Add live demo URL to README

## Test Plan

Manual testing:
1. Visit the hex grid prototype at https://hex-grid-prototype.pages.dev/
2. Verify the GitHub link appears in the bottom-right corner and links to the correct repository
3. Check that the README displays the live demo URL