### PR TITLE
Add Path to Victory and Open Questions strategic docs

### DIFF
--- a/docs/context-library/sources/open-questions.md
+++ b/docs/context-library/sources/open-questions.md
@@ -1,0 +1,113 @@
+# LifeBuild: Open Questions & Uncertainties
+
+> **Living strategic document.** Ranked list of what we don't know yet. Updated as questions get resolved or new ones emerge.
+
+**Snapshot Date:** 2026-02-19  
+**Status:** Draft — needs team review and ranking validation
+
+---
+
+## How to Use This Document
+
+1. **Questions are ranked** by (impact × uncertainty). High impact + high uncertainty = top of list.
+2. **Each question has a resolution path** — what would answer it?
+3. **Resolved questions move to the bottom** with their answer noted.
+4. **Review weekly** — reprioritize as we learn.
+
+---
+
+## Active Questions (Ranked)
+
+### 🔴 Critical Uncertainties
+
+**Q1: Does the sanctuary metaphor resonate emotionally?**
+- **Impact:** Fatal if wrong — the entire product rests on this
+- **Uncertainty:** High — we believe it, but haven't validated with enough users
+- **Resolution path:** 20+ onboarding sessions with target users, measure emotional response
+- **Signal we're looking for:** Users spontaneously use sanctuary language, describe feeling "at home"
+
+**Q2: Can Jarvis be good enough to feel like a real steward?**
+- **Impact:** Fatal if wrong — a mediocre AI advisor is worse than none
+- **Uncertainty:** High — prompt engineering vs fine-tuning vs architecture questions
+- **Resolution path:** Jarvis quality benchmarking, user perception testing
+- **Signal we're looking for:** Users talk TO Jarvis, not ABOUT Jarvis ("I asked Jarvis" not "the AI said")
+
+**Q3: Will users actually return after onboarding?**
+- **Impact:** Fatal if wrong — retention is everything
+- **Uncertainty:** High — novelty vs habit formation unknown
+- **Resolution path:** Ship return experience, measure D7/D30 retention
+- **Signal we're looking for:** >40% D7 retention, users mention LifeBuild in daily routine
+
+### 🟡 Important Uncertainties
+
+**Q4: Is "builder context" a real moat or will it be commoditized?**
+- **Impact:** High — determines long-term defensibility
+- **Uncertainty:** Medium — depends on AI ecosystem evolution
+- **Resolution path:** Monitor MCP developments, test context portability scenarios
+- **Signal we're looking for:** Users resist exporting context, say "Jarvis knows me"
+
+**Q5: What's our network effect story?**
+- **Impact:** High — could be the strongest long-term moat
+- **Uncertainty:** High — we haven't designed for this yet
+- **Resolution path:** Design spike on network effect mechanics
+- **Signal we're looking for:** Feature that gets better with more users
+
+**Q6: Should agents do work or just advise?**
+- **Impact:** High — changes the entire product surface
+- **Uncertainty:** Medium — technical feasibility clear, user desire unclear
+- **Resolution path:** Test "Jarvis did this for you" vs "Jarvis suggests you do this"
+- **Signal we're looking for:** Users delegate tasks, not just ask questions
+
+**Q7: What's the right capacity/energy model?**
+- **Impact:** Medium — core gameplay loop depends on it
+- **Uncertainty:** Medium — Maintain/Invest/Spend is designed but untested
+- **Resolution path:** Prototype capacity UI, test with users
+- **Signal we're looking for:** Users say "I finally understand where my energy goes"
+
+### 🟢 Open but Lower Priority
+
+**Q8: How do we price this?**
+- **Impact:** Medium — affects business model
+- **Uncertainty:** Medium — subscription obvious, but what tier structure?
+- **Resolution path:** Competitor analysis, willingness-to-pay research
+- **Signal we're looking for:** Price point where churn is low and NPS is high
+
+**Q9: What integrations matter most?**
+- **Impact:** Medium — affects launch scope
+- **Uncertainty:** Low — calendar/email/tasks are obvious
+- **Resolution path:** User research on existing tool landscape
+- **Signal we're looking for:** "If LifeBuild connected to X, I'd use it daily"
+
+**Q10: How do we handle multi-person households?**
+- **Impact:** Medium — affects expansion
+- **Uncertainty:** Medium — shared sanctuaries are complex
+- **Resolution path:** Design exploration, defer to post-PMF
+- **Signal we're looking for:** Couples asking for shared features
+
+---
+
+## Resolved Questions
+
+| Question | Resolution | Date | Notes |
+|----------|------------|------|-------|
+| D1: Algorithmic hex placement? | Yes — for Release 1 | 2026-02-17 | Builder places later |
+| D2: Jarvis UI — route or overlay? | Overlay | 2026-02-17 | Chat panel, not separate page |
+| D3: One project per hex? | Yes | 2026-02-17 | Simplicity wins |
+| D4: Category room agents? | Deferred | 2026-02-17 | Post-Release 1 |
+| D5: Campfire scripted vs improv? | Guided improv | 2026-02-18 | Structure with flexibility |
+| D6: Jarvis crisis assessment? | Pattern-based | 2026-02-18 | Three modes: crisis/transition/growth |
+| D7: Builder context storage? | LiveStore | 2026-02-17 | Local-first |
+
+---
+
+## Question Intake
+
+When a new uncertainty emerges:
+1. Add it to the bottom of Active Questions
+2. Estimate impact and uncertainty
+3. Define resolution path
+4. Review and rank in next weekly sync
+
+---
+
+*This document is the team's uncertainty radar. If we're not updating it, we're not learning.*

--- a/docs/context-library/sources/path-to-victory.md
+++ b/docs/context-library/sources/path-to-victory.md
@@ -1,0 +1,107 @@
+# LifeBuild: Path to Victory
+
+> **Living strategic document.** Unlike other sources, this is actively updated as the path becomes clearer. Snapshot date reflects last major revision.
+
+**Snapshot Date:** 2026-02-19  
+**Status:** Draft — needs team review
+
+---
+
+## What "Victory" Looks Like
+
+LifeBuild wins when it becomes **the place where thoughtful people manage their lives** — not as a task list or calendar, but as a living sanctuary they actively cultivate.
+
+**Concrete victory conditions:**
+
+1. **Product-Market Fit Signal:** Users who complete onboarding return 3+ times per week for 8+ weeks
+2. **Word of Mouth:** >50% of new users come from referrals, not marketing
+3. **Outcome Proof:** Users report measurably reduced overwhelm and increased intentionality (qualitative + NPS)
+4. **Revenue Viability:** Sustainable unit economics on a subscription model
+5. **Moat Establishment:** Full context (builder context) becomes deep enough that switching costs are real
+
+---
+
+## The Path
+
+### Phase 0: Foundation (Current → Release 1)
+**Goal:** Prove the campfire works — first-time users feel the magic
+
+- [ ] Ship Release 1: The Campfire
+- [ ] Validate onboarding flow (campfire → first project → first hex)
+- [ ] Jarvis can hold a useful conversation about your life
+- [ ] Spatial map feels meaningful, not gimmicky
+- [ ] 10 alpha users complete onboarding and return
+
+**Key bet:** The "sanctuary building" metaphor resonates emotionally, not just functionally
+
+### Phase 1: Retention (Release 2-3)
+**Goal:** Users come back — the sanctuary becomes part of their routine
+
+- [ ] Return experience works (second visit feels natural)
+- [ ] Builder context accumulates and becomes useful
+- [ ] Jarvis gets noticeably better as it learns you
+- [ ] Projects complete and new ones emerge organically
+- [ ] Weekly active users stabilize (not just novelty)
+
+**Key bet:** Context compounds — Jarvis knowing your patterns is genuinely valuable
+
+### Phase 2: Expansion (Release 4-6)
+**Goal:** The sanctuary grows — users invest in building out their space
+
+- [ ] Multiple attendants (agents) doing real work
+- [ ] Integrations bring external data into the sanctuary
+- [ ] Capacity system (Maintain/Invest/Spend) provides real guidance
+- [ ] Users feel the "map as scoreboard" — their life visible
+
+**Key bet:** Agents doing work for you (not just advising) is a step change in value
+
+### Phase 3: Network (Release 7-9)
+**Goal:** LifeBuild becomes a community, not just a tool
+
+- [ ] Shared patterns/templates across users (anonymized)
+- [ ] Agent training compounds across the user base
+- [ ] Brand becomes a statement of values ("I'm a LifeBuilder")
+- [ ] Network effects make the product better for everyone
+
+**Key bet:** Network effects in life management are possible and valuable
+
+### Phase 4: Dominance
+**Goal:** LifeBuild is the default answer to "how do I manage my life?"
+
+- [ ] Category definition (we created "sanctuary building")
+- [ ] Trusted brand (people recommend us without hesitation)
+- [ ] Full context moat (can't export your accumulated understanding)
+- [ ] Outcome-based pricing viable (pay for results, not seats)
+
+---
+
+## Critical Path Items (Now)
+
+The immediate blockers between here and Phase 0 completion:
+
+1. **Ship The Campfire** — Release 1 must land
+2. **Validate emotional resonance** — does the metaphor work?
+3. **Jarvis quality bar** — is the steward conversation good enough?
+4. **Return experience** — do people come back?
+
+---
+
+## What Could Kill Us
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Metaphor doesn't resonate | Medium | Fatal | Test with real users fast, be willing to pivot framing |
+| Jarvis isn't good enough | Medium | High | Invest in prompt craft, consider fine-tuning |
+| Context becomes portable | Low (for now) | High | Make context active (does things), not just passive (stores things) |
+| Bigger player copies us | Medium | Medium | Move fast, build brand, establish network effects |
+| Users don't return | High | Fatal | Obsess over return experience, build habits |
+
+---
+
+## Open Questions
+
+See: [[open-questions.md]]
+
+---
+
+*This document is a living path, not a frozen source. Update as we learn.*


### PR DESCRIPTION
## Summary

Two living documents for strategic clarity, inspired by the Ben Kuhn playbook discussion:

### path-to-victory.md
Concrete steps from current state to "we won":
- Victory conditions defined
- Four phases mapped (Foundation → Retention → Expansion → Network → Dominance)
- Critical path items identified
- Risk matrix included

### open-questions.md
Ranked list of uncertainties with resolution paths:
- 🔴 3 critical questions (metaphor resonance, Jarvis quality, retention)
- 🟡 4 important questions (moat, network effects, agents, capacity model)
- 🟢 3 lower-priority questions (pricing, integrations, multi-person)
- Resolved questions tracked (D1-D7)

## Note on Sources Convention

These are **living documents**, unlike other sources which are frozen. They include explicit language about being actively updated.

## Review Checklist

- [ ] Ranking of questions makes sense
- [ ] Victory conditions are right
- [ ] Phase definitions align with team thinking
- [ ] Missing questions or risks?