### PR TITLE
Upgrade blocker tracking and decision resolution protocols

### DIFF
--- a/.claude/agents/george.md
+++ b/.claude/agents/george.md
@@ -207,7 +207,7 @@ See `.claude/skills/george/job-decision-resolution.md` for the full procedure, o
 - Stations: DECIDE, PATCH, MAKE, SHAPE
 - Flow States: Queued, On the Line, Blocked (Andon), QC Gate, Review, Rework, Shipped
 - Takt owners: Danvers (product/design), Jess (architecture), AI (building)
-- Board field reference (IDs, commands): `.claude/skills/george/board-fields.md`
+- Board field reference (IDs, commands, **intake protocol**): `.claude/skills/george/board-fields.md` — covers both board #4 (Release 1) and board #5 (Factory & Library)
 - Dashboard script: `./scripts/factory-dashboard`
 - History script: `./scripts/factory-history`
 - Dashboard saves snapshots to `.context/factory-snapshots.jsonl`
@@ -215,8 +215,14 @@ See `.claude/skills/george/job-decision-resolution.md` for the full procedure, o
 - Decision resolution procedure: `.claude/skills/george/job-decision-resolution.md`
 - Propagation Map format: Structured metadata in D-issues that maps each decision option to library cards, GitHub issues, cascading decisions, and scope changes
 - Propagation trigger: `/george propagate` comment on a closed D-issue, or auto-scan at shift start
-- Provenance log: `docs/context-library/constellation-log.jsonl` — resolution entries have `"task_type": "resolution"`
+- Provenance log: `docs/context-library/constellation-log.jsonl` — resolution entries have `"task_type": "resolution"`, with `"propagation_status": "started"|"complete"`
 - D-issues for Release 1: D1 (#607), D2 (#608), D3 (#609), D4 (#610), D5 (#593), D6 (#594), D7 (#595), D8 (#606)
+- **Blocker tracking:** GitHub native `blockedBy`/`blocking` relationships are the source of truth. Prose "Blocked by" sections in issue bodies provide human-readable context. Both must be maintained together.
+  - Query blockers: `gh api graphql -f query='{ repository(owner: "sociotechnica-org", name: "lifebuild") { issue(number: N) { blockedBy(first: 10) { nodes { number title state } } } } }'`
+  - Add blocker: `addBlockedBy(input: { issueId: "NODE_ID", blockingIssueId: "BLOCKER_NODE_ID" })`
+  - Remove blocker: `removeBlockedBy(input: { issueId: "NODE_ID", blockingIssueId: "BLOCKER_NODE_ID" })`
+  - Get node ID: `gh api repos/sociotechnica-org/lifebuild/issues/<number> --jq '.node_id'`
+- Sweep runbook for off-grid agents: `.context/sweep-unpropagated-decisions.md` (blocker health only — full factory sweep job planned at #645)
 
 ### The Factory Model
 

--- a/.claude/skills/george/board-fields.md
+++ b/.claude/skills/george/board-fields.md
@@ -1,10 +1,57 @@
-# Board Field Reference — Project Board #4
+# Board Field Reference
 
-> **Project:** Release 1: The Campfire
+Two factory floor boards. Same field names, different IDs.
+
+---
+
+## New Item Intake — Required Protocol
+
+**Every issue added to a factory board MUST have all four fields set.** An item with no Station is invisible to the dashboard and sweep agents.
+
+### Required fields
+
+| Field | Required? | How to decide |
+|-------|-----------|---------------|
+| **Status** | Yes | `Todo` for new work, `In Progress` if starting now, `Blocked` if waiting on something |
+| **Station** | Yes | `DECIDE` = human decision needed, `PATCH` = library/docs update, `MAKE` = build work, `SHAPE` = prototyping/discovery |
+| **Flow State** | Yes | `Queued` for new items, `On the Line` if actively working, `Blocked (Andon)` if blocked |
+| **Takt** | Yes | `Danvers` = product/design, `Jess` = architecture, `AI` = agent-executable |
+
+### Intake steps
+
+```bash
+# 1. Create the issue
+gh issue create -R sociotechnica-org/lifebuild --title "Title" --body "Body"
+
+# 2. Add to the board
+gh project item-add <BOARD_NUMBER> --owner sociotechnica-org --url <issue-url>
+
+# 3. Get the item ID
+ITEM_ID=$(gh project item-list <BOARD_NUMBER> --owner sociotechnica-org --format json | jq -r '.items[] | select(.content.number == ISSUE_NUMBER) | .id')
+
+# 4. Set ALL four fields (use IDs from the relevant board section below)
+gh project item-edit --project-id <PROJECT_ID> --id "$ITEM_ID" --field-id <STATUS_FIELD> --single-select-option-id <STATUS_OPTION>
+gh project item-edit --project-id <PROJECT_ID> --id "$ITEM_ID" --field-id <STATION_FIELD> --single-select-option-id <STATION_OPTION>
+gh project item-edit --project-id <PROJECT_ID> --id "$ITEM_ID" --field-id <FLOW_FIELD> --single-select-option-id <FLOW_OPTION>
+gh project item-edit --project-id <PROJECT_ID> --id "$ITEM_ID" --field-id <TAKT_FIELD> --single-select-option-id <TAKT_OPTION>
+
+# 5. Add native blocker relationships if blocked
+ISSUE_ID=$(gh api repos/sociotechnica-org/lifebuild/issues/<number> --jq '.node_id')
+BLOCKER_ID=$(gh api repos/sociotechnica-org/lifebuild/issues/<blocker-number> --jq '.node_id')
+gh api graphql -f query="mutation { addBlockedBy(input: { issueId: \"$ISSUE_ID\", blockingIssueId: \"$BLOCKER_ID\" }) { issue { number } blockingIssue { number } } }"
+```
+
+### Project-type issues (containers)
+
+Project issues are parents — they don't go through factory stations themselves. Set **Status** only (to track lifecycle). Leave Station, Flow State, and Takt unset. Sub-issues get the full treatment.
+
+---
+
+## Board #4 — Release 1: The Campfire
+
 > **Project ID:** `PVT_kwDOBzJqv84BPOmG`
 > **Board URL:** https://github.com/orgs/sociotechnica-org/projects/4
-
-## Field IDs and Option IDs
+> **Board number:** `4`
 
 ### Status (`PVTSSF_lADOBzJqv84BPOmGzg9sqAQ`)
 
@@ -130,4 +177,60 @@ Queued → On the Line → QC Gate → Review → Shipped
        Blocked (Andon) → (unblocked) ────────┤
                                               │
               Rework ─────────────────────────┘
+```
+
+---
+
+## Board #5 — Factory & Library
+
+> **Project ID:** `PVT_kwDOBzJqv84BPoAQ`
+> **Board URL:** https://github.com/orgs/sociotechnica-org/projects/5
+> **Board number:** `5`
+
+### Status (`PVTSSF_lADOBzJqv84BPoAQzg9-v94`)
+
+| Option        | ID         |
+|---------------|------------|
+| Todo          | `f75ad846` |
+| In Progress   | `47fc9ee4` |
+| In Review     | `bd9c404b` |
+| Done          | `98236657` |
+
+### Station (`PVTSSF_lADOBzJqv84BPoAQzg9-wAM`)
+
+| Option  | ID         |
+|---------|------------|
+| DECIDE  | `62fcc83e` |
+| PATCH   | `f57e88dc` |
+| MAKE    | `97efd016` |
+| SHAPE   | `cc9e8481` |
+
+### Flow State (`PVTSSF_lADOBzJqv84BPoAQzg9-wAk`)
+
+| Option          | ID         |
+|-----------------|------------|
+| Queued          | `e522186b` |
+| On the Line     | `f4850abf` |
+| Blocked (Andon) | `34dee8be` |
+| QC Gate         | `c9cae6f8` |
+| Review          | `edd1c28e` |
+| Rework          | `4e942b0e` |
+| Shipped         | `26e01b14` |
+
+### Takt (`PVTSSF_lADOBzJqv84BPoAQzg9-wBQ`)
+
+| Option  | ID         |
+|---------|------------|
+| Danvers | `67735a1f` |
+| Jess    | `a2de3100` |
+| AI      | `1383234f` |
+
+### Board #5 Command Templates
+
+```bash
+# Look up item ID
+ITEM_ID=$(gh project item-list 5 --owner sociotechnica-org --format json | jq -r '.items[] | select(.content.number == ISSUE_NUMBER) | .id')
+
+# Set a field
+gh project item-edit --project-id PVT_kwDOBzJqv84BPoAQ --id "$ITEM_ID" --field-id FIELD_ID --single-select-option-id OPTION_ID
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,8 @@ gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> --field-id <STATUS
 
 - **Parent Issues**: Only use the "Parent issue" feature for issues with type "Project". Never set a parent issue on regular issues. Only ONE level of sub-issues - sub-issues should not have their own sub-issues.
 - **Sub-issues**: Use the REST API to link issues as sub-issues to Project-type issues. For smaller sub-tasks within an issue, use markdown checklists instead of creating separate issues.
-- **Adding to Projects**: Use `gh project item-add <project-number> --owner sociotechnica-org --url <issue-url>`
+- **Adding to Projects**: Use `gh project item-add <project-number> --owner sociotechnica-org --url <issue-url>`. **IMPORTANT:** After adding, you MUST set all four board fields (Status, Station, Flow State, Takt). Items with missing fields are invisible to dashboard and sweep agents. See `.claude/skills/george/board-fields.md` for the full intake protocol, field IDs, and option IDs for each board.
+- **Blocker tracking**: Use GitHub native `blockedBy`/`blocking` relationships as the source of truth. Also maintain prose "Blocked by" sections in issue bodies for human context. See `.claude/skills/george/board-fields.md` for API commands.
 
 ### Common Workflows
 


### PR DESCRIPTION
## Summary

Upgrade three interrelated factory floor protocols to fix blocker tracking gaps and improve propagation safety. Introduces log-first-propagate-second for decision resolution with anchor entries that distinguish unpropagated / partially-propagated / fully-propagated decisions. Replaces prose-only blocker tracking with GitHub native relationships as source of truth. Adds required New Item Intake protocol to board-fields.md with mandatory field setup for any issue added to a factory board. Board #5 (Factory & Library) field reference and command templates now documented.

## Test Plan

- Reviewed all 4 file changes to verify protocol completeness
- Tested board intake protocol by creating and setting up issue #646
- Verified blocker relationships created on 11 existing issues and queryable via GraphQL
- Board #5 and board #4 field IDs and option IDs independently validated

## Context

Triggered by finding issue #601 had a stale D5 blocker — D5 was closed but never formally propagated. Investigation revealed 3 of 8 D-issues (37.5%) resolved outside George Mode 4, creating provenance gaps and stale blockers on multiple issues. This commit ships the protocols to prevent recurrence.