### PR TITLE
chore: add repo-level Codex attribution

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,1 @@
+commit_attribution = "Codex 5.3 <noreply@openai.com>"


### PR DESCRIPTION
## Summary

Add repo-local Codex configuration so commits created through Codex in this repository include the configured co-author attribution.

## Test Plan

- `pnpm lint-all`
- `pnpm test`
- `CI=true pnpm test:e2e`

## Screenshots/Videos

N/A (configuration-only change)
