### PR TITLE
PR4: Add state-driven hex tile treatments

### DIFF
--- a/packages/web/e2e/life-map-placement.spec.ts
+++ b/packages/web/e2e/life-map-placement.spec.ts
@@ -139,7 +139,7 @@ const selectPlacedTile = async (
   const removeButton = panel.getByRole('button', { name: 'Remove from map' })
   const selectionHint = panel.getByText('Click a placed hex tile on the map to select it.')
   const selectionTrigger = panel.getByRole('button', { name: 'Select placed tile' })
-  const candidates: Array<[number, number]> = [
+  const focusedCandidates: Array<[number, number]> = [
     [basePoint.x, basePoint.y],
     [basePoint.x + 0.015, basePoint.y],
     [basePoint.x - 0.015, basePoint.y],
@@ -148,6 +148,13 @@ const selectPlacedTile = async (
     [basePoint.x + 0.03, basePoint.y + 0.015],
     [basePoint.x - 0.03, basePoint.y - 0.015],
   ]
+  const broadCandidates: Array<[number, number]> = []
+  for (const y of [0.28, 0.36, 0.44, 0.52, 0.6, 0.68]) {
+    for (const x of [0.2, 0.28, 0.36, 0.44, 0.52, 0.6, 0.68]) {
+      broadCandidates.push([x, y])
+    }
+  }
+  const candidates = [...focusedCandidates, ...broadCandidates]
 
   for (const [x, y] of candidates) {
     if ((await removeButton.count()) > 0) {

--- a/packages/web/src/components/hex-map/HexGrid.tsx
+++ b/packages/web/src/components/hex-map/HexGrid.tsx
@@ -5,7 +5,7 @@ import { Html } from '@react-three/drei'
 import React from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { HexCell } from './HexCell.js'
-import { HexTile } from './HexTile.js'
+import { HexTile, type HexTileVisualState, type HexTileWorkstream } from './HexTile.js'
 import { truncateLabel } from './labelUtils.js'
 import { isReservedProjectCoord } from './placementRules.js'
 
@@ -19,6 +19,8 @@ export type PlacedHexTile = {
   projectName: string
   category?: string | null
   categoryColor: string
+  visualState?: HexTileVisualState
+  workstream?: HexTileWorkstream
   isCompleted?: boolean
   onClick?: () => void
 }
@@ -157,6 +159,8 @@ export function HexGrid({
           coord={tile.coord}
           projectName={tile.projectName}
           categoryColor={tile.categoryColor}
+          visualState={tile.visualState}
+          workstream={tile.workstream}
           isCompleted={tile.isCompleted}
           isSelected={selectedPlacedProjectId === tile.projectId}
           allowCompletedClick={isPlacementMode || isSelectingPlacedProject}

--- a/packages/web/src/components/hex-map/HexTile.stories.tsx
+++ b/packages/web/src/components/hex-map/HexTile.stories.tsx
@@ -4,11 +4,13 @@ import { createHex } from '@lifebuild/shared/hex'
 import React from 'react'
 import { CameraRig } from './CameraRig.js'
 import { HexCell } from './HexCell.js'
-import { HexTile } from './HexTile.js'
+import { HexTile, type HexTileVisualState, type HexTileWorkstream } from './HexTile.js'
 
 type HexTilePreviewProps = {
   projectName: string
   categoryColor: string
+  visualState?: HexTileVisualState
+  workstream?: HexTileWorkstream
   isCompleted?: boolean
   isSelected?: boolean
 }
@@ -16,6 +18,8 @@ type HexTilePreviewProps = {
 const HexTilePreview: React.FC<HexTilePreviewProps> = ({
   projectName,
   categoryColor,
+  visualState = 'active',
+  workstream = null,
   isCompleted = false,
   isSelected = false,
 }) => {
@@ -36,6 +40,8 @@ const HexTilePreview: React.FC<HexTilePreviewProps> = ({
           coord={createHex(0, 0)}
           projectName={projectName}
           categoryColor={categoryColor}
+          visualState={visualState}
+          workstream={workstream}
           isCompleted={isCompleted}
           isSelected={isSelected}
           onClick={() => {}}
@@ -67,7 +73,24 @@ export const ActiveProject: Story = {
   args: {
     projectName: 'Launch life map pilot',
     categoryColor: '#10B981',
-    isCompleted: false,
+    visualState: 'active',
+  },
+}
+
+export const PlanningProject: Story = {
+  args: {
+    projectName: 'Sketch summer reset plan',
+    categoryColor: '#F97316',
+    visualState: 'planning',
+  },
+}
+
+export const WorkAtHand: Story = {
+  args: {
+    projectName: 'Ship relational check-in loop',
+    categoryColor: '#3B82F6',
+    visualState: 'work-at-hand',
+    workstream: 'gold',
   },
 }
 
@@ -75,6 +98,7 @@ export const CompletedProject: Story = {
   args: {
     projectName: 'Finish tax filing workflow',
     categoryColor: '#3B82F6',
+    visualState: 'completed',
     isCompleted: true,
   },
 }

--- a/packages/web/src/components/hex-map/HexTile.test.tsx
+++ b/packages/web/src/components/hex-map/HexTile.test.tsx
@@ -43,10 +43,10 @@ describe('HexTile click behavior', () => {
         />
       )
 
-      const mesh = container.querySelector('mesh')
-      expect(mesh).not.toBeNull()
+      const clickableRoot = container.querySelector('group') ?? container.querySelector('mesh')
+      expect(clickableRoot).not.toBeNull()
 
-      fireEvent.click(mesh as Element)
+      fireEvent.click(clickableRoot as Element)
       expect(onClick).toHaveBeenCalledTimes(1)
     } finally {
       consoleErrorSpy.mockRestore()
@@ -68,10 +68,10 @@ describe('HexTile click behavior', () => {
         />
       )
 
-      const mesh = container.querySelector('mesh')
-      expect(mesh).not.toBeNull()
+      const clickableRoot = container.querySelector('group') ?? container.querySelector('mesh')
+      expect(clickableRoot).not.toBeNull()
 
-      fireEvent.click(mesh as Element)
+      fireEvent.click(clickableRoot as Element)
       expect(onClick).not.toHaveBeenCalled()
     } finally {
       consoleErrorSpy.mockRestore()

--- a/packages/web/src/components/hex-map/HexTile.tsx
+++ b/packages/web/src/components/hex-map/HexTile.tsx
@@ -11,6 +11,8 @@ const TILE_HEIGHT = 0.22
 const TILE_LIFT = 0.24
 const HOVER_LIFT = 0.04
 const MAX_LABEL_LENGTH = 24
+const INNER_TOP_RADIUS = TILE_RADIUS * 0.82
+const INNER_TOP_HEIGHT = 0.035
 
 const getInitials = (value: string): string => {
   const words = value.trim().split(/\s+/).filter(Boolean)
@@ -20,10 +22,55 @@ const getInitials = (value: string): string => {
   return value.slice(0, 2).toUpperCase()
 }
 
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(max, Math.max(min, value))
+}
+
+const parseHexColor = (color: string): [number, number, number] => {
+  const normalized = color.trim().replace('#', '')
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return [139, 134, 128]
+  }
+
+  const red = parseInt(normalized.slice(0, 2), 16)
+  const green = parseInt(normalized.slice(2, 4), 16)
+  const blue = parseInt(normalized.slice(4, 6), 16)
+  return [red, green, blue]
+}
+
+const toHexColor = ([red, green, blue]: [number, number, number]): string => {
+  return `#${[red, green, blue]
+    .map(value => clamp(Math.round(value), 0, 255).toString(16).padStart(2, '0'))
+    .join('')}`
+}
+
+const mixHexColors = (base: string, target: string, weight: number): string => {
+  const ratio = clamp(weight, 0, 1)
+  const [baseR, baseG, baseB] = parseHexColor(base)
+  const [targetR, targetG, targetB] = parseHexColor(target)
+
+  return toHexColor([
+    baseR + (targetR - baseR) * ratio,
+    baseG + (targetG - baseG) * ratio,
+    baseB + (targetB - baseB) * ratio,
+  ])
+}
+
+const STREAM_GLOW_COLORS = {
+  gold: '#d8a650',
+  silver: '#c5ced8',
+  bronze: '#c48b5a',
+} as const
+
+export type HexTileVisualState = 'planning' | 'active' | 'work-at-hand' | 'completed'
+export type HexTileWorkstream = 'gold' | 'silver' | 'bronze' | null
+
 type HexTileProps = {
   coord: HexCoord
   projectName: string
   categoryColor: string
+  visualState?: HexTileVisualState
+  workstream?: HexTileWorkstream
   isCompleted?: boolean
   isSelected?: boolean
   allowCompletedClick?: boolean
@@ -34,6 +81,8 @@ export function HexTile({
   coord,
   projectName,
   categoryColor,
+  visualState,
+  workstream = null,
   isCompleted = false,
   isSelected = false,
   allowCompletedClick = false,
@@ -41,11 +90,38 @@ export function HexTile({
 }: HexTileProps) {
   const [isHovered, setIsHovered] = useState(false)
   const [x, z] = useMemo(() => hexToWorld(coord, BASE_HEX_SIZE), [coord.q, coord.r, coord.s])
-  const canClick = typeof onClick === 'function' && (!isCompleted || allowCompletedClick)
-  const canHover = canClick
-  const isHighlighted = isHovered || isSelected
+  const resolvedVisualState = visualState ?? (isCompleted ? 'completed' : 'active')
+  const isCompletedState = resolvedVisualState === 'completed'
+  const canClick = typeof onClick === 'function' && (!isCompletedState || allowCompletedClick)
+  const isHoverEnabled = canClick && !isCompletedState
+  const isHighlighted = (isHoverEnabled && isHovered) || isSelected
   const label = useMemo(() => truncateLabel(projectName, MAX_LABEL_LENGTH), [projectName])
   const initials = useMemo(() => getInitials(projectName), [projectName])
+
+  const categoryEdgeColor = useMemo(() => {
+    if (isCompletedState) {
+      return '#a7a29a'
+    }
+    if (resolvedVisualState === 'planning') {
+      return mixHexColors(categoryColor, '#9d968d', 0.4)
+    }
+    return categoryColor
+  }, [categoryColor, isCompletedState, resolvedVisualState])
+
+  const streamGlowColor =
+    resolvedVisualState === 'work-at-hand' ? STREAM_GLOW_COLORS[workstream ?? 'bronze'] : null
+
+  const emissiveColor = streamGlowColor ?? (isHighlighted ? '#6e5a45' : '#000000')
+  const emissiveIntensity = streamGlowColor
+    ? isHighlighted
+      ? 0.26
+      : 0.2
+    : isHovered
+      ? 0.12
+      : isSelected
+        ? 0.18
+        : 0
+  const innerTopColor = isCompletedState ? '#ddd5ca' : isHighlighted ? '#fff2e2' : '#f5ead6'
 
   useEffect(() => {
     return () => {
@@ -54,70 +130,89 @@ export function HexTile({
   }, [])
 
   return (
-    <group position={[x, TILE_LIFT + (isHovered ? HOVER_LIFT : 0) + (isSelected ? 0.02 : 0), z]}>
-      <mesh
-        onClick={event => {
-          if (!canClick) {
-            return
-          }
-          event.stopPropagation()
-          onClick?.()
-        }}
-        onPointerOver={event => {
-          event.stopPropagation()
-          if (!canHover) {
-            return
-          }
+    <group
+      position={[
+        x,
+        TILE_LIFT + (isHoverEnabled && isHovered ? HOVER_LIFT : 0) + (isSelected ? 0.02 : 0),
+        z,
+      ]}
+      onClick={event => {
+        if (!canClick) {
+          return
+        }
+        event.stopPropagation()
+        onClick?.()
+      }}
+      onPointerOver={event => {
+        event.stopPropagation()
+        document.body.style.cursor = canClick ? 'pointer' : 'default'
+        if (isHoverEnabled) {
           setIsHovered(true)
-          document.body.style.cursor = 'pointer'
-        }}
-        onPointerOut={() => {
-          setIsHovered(false)
-          document.body.style.cursor = 'default'
-        }}
-      >
+        }
+      }}
+      onPointerOut={event => {
+        event.stopPropagation()
+        setIsHovered(false)
+        document.body.style.cursor = 'default'
+      }}
+    >
+      <mesh>
         <cylinderGeometry args={[TILE_RADIUS, TILE_RADIUS, TILE_HEIGHT, 6]} />
         {/* material-0 = side faces (tube) */}
         <meshStandardMaterial
           attach='material-0'
-          color={isCompleted ? '#a7a29a' : categoryColor}
+          color={categoryEdgeColor}
           roughness={0.62}
           metalness={0.12}
         />
-        {/* material-1 = top cap */}
+        {/* material-1 = top cap (category ring base) */}
         <meshStandardMaterial
           attach='material-1'
-          color={isCompleted ? '#d4cec4' : isHighlighted ? '#faf4e8' : '#f5ead6'}
-          emissive={isHighlighted ? '#6e5a45' : '#000000'}
-          emissiveIntensity={isHovered ? 0.12 : isSelected ? 0.18 : 0}
+          color={categoryEdgeColor}
+          emissive={emissiveColor}
+          emissiveIntensity={emissiveIntensity}
           roughness={0.9}
           metalness={0.03}
         />
         {/* material-2 = bottom cap */}
         <meshStandardMaterial
           attach='material-2'
-          color={isCompleted ? '#c6c0b7' : '#e7d8c2'}
+          color={isCompletedState ? '#c6c0b7' : '#e7d8c2'}
           roughness={0.85}
           metalness={0.02}
         />
+
+        {/* Inner top disk leaves a visible category ring around the edge. */}
+        <mesh position={[0, TILE_HEIGHT / 2 + INNER_TOP_HEIGHT / 2, 0]}>
+          <cylinderGeometry args={[INNER_TOP_RADIUS, INNER_TOP_RADIUS, INNER_TOP_HEIGHT, 6]} />
+          <meshStandardMaterial
+            color={innerTopColor}
+            emissive={streamGlowColor ?? '#000000'}
+            emissiveIntensity={streamGlowColor ? 0.08 : 0}
+            roughness={0.9}
+            metalness={0.03}
+          />
+        </mesh>
       </mesh>
 
       <Text
+        raycast={() => null}
         position={[0, TILE_HEIGHT / 2 + 0.12, 0.16]}
         rotation={[-0.52, 0, 0]}
         fontSize={0.34}
         textAlign='center'
-        color={isCompleted ? '#6f6a62' : '#ffffff'}
+        color={isCompletedState ? '#6f6a62' : '#ffffff'}
         anchorX='center'
         anchorY='middle'
         outlineWidth={0.03}
-        outlineColor={isCompleted ? '#d4cec4' : '#3d2e1e'}
+        outlineColor={isCompletedState ? '#d4cec4' : '#3d2e1e'}
       >
         {initials}
       </Text>
 
-      {isHovered && (
+      {isHoverEnabled && isHovered && (
         <Text
+          raycast={() => null}
           position={[0, TILE_HEIGHT / 2 + 0.42, 0.02]}
           rotation={[-0.52, 0, 0]}
           fontSize={0.22}


### PR DESCRIPTION
## Summary
- implement PR4 visual state treatments for Life Map hex tiles while preserving PR3 placement UX
- add category-colored edge ring rendering, planning-state desaturation, completed-state greyscale, and Work-at-Hand stream glow accents
- derive tile visual state from lifecycle + table activity in `LifeMap` and plumb state through `HexGrid` to `HexTile`
- expand `HexTile` Storybook coverage for planning and Work-at-Hand variants
- harden tile-selection E2E candidate scanning and align unit tests with new group-level click handling

## Changelog
- Add state-driven tile visuals (`planning`, `active`, `work-at-hand`, `completed`) with stream glow colors for Work-at-Hand
- Update Life Map tile projection logic to map lifecycle + active table state into visual presentation
- Improve placement E2E robustness and update HexTile tests for event propagation changes

## Validation
- `pnpm lint-all`
- `pnpm test`
- `CI=true pnpm test:e2e`
