### PR TITLE
fix: hoist @sinclair/typebox for pi-coding-agent peer dep

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,5 @@ optional=true
 # Allow build scripts for native dependencies (bypasses pnpm build approval)
 ignore-scripts=false
 auto-install-peers=true
+# Hoist typebox so pi-coding-agent can find it (peer dep issue)
+public-hoist-pattern[]=@sinclair/typebox


### PR DESCRIPTION
## Problem

Render deploys failing with:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@sinclair/typebox' imported from .../pi-coding-agent/dist/core/model-registry.js
```

## Cause

pnpm's strict dependency isolation prevents `@mariozechner/pi-coding-agent` from resolving `@sinclair/typebox`, even though it's listed as a direct dependency in the server package.

## Fix

Add `@sinclair/typebox` to `public-hoist-pattern` in `.npmrc` so it's available at root `node_modules/`.

## Testing

- [x] Server starts locally without error
- [x] typebox symlinked to root node_modules