### PR TITLE
Restructure rationale layer: Strategy → Product Thesis

### DIFF
--- a/.claude/agents/conan.md
+++ b/.claude/agents/conan.md
@@ -50,7 +50,7 @@ Load the retrieval profile for the target type from `retrieval-profiles.md`. The
 
 1. Read each seed card in full
 2. Extract all `[[wikilinks]]` from seed cards — these are relationship edges
-3. Follow mandatory upstream links per the profile (Strategy/Principle chains, parent containers, conforming Standards)
+3. Follow mandatory upstream links per the profile (Product Thesis/Principle chains, parent containers, conforming Standards)
 4. `Grep` for the seed card names across the library to find cards that reference them (reverse edges)
 5. Stop at the hop depth specified by the profile
 
@@ -59,7 +59,7 @@ Load the retrieval profile for the target type from `retrieval-profiles.md`. The
 The retrieval profile lists mandatory card categories for the target type. Verify:
 
 - [ ] All mandatory categories have at least 1 card
-- [ ] WHY chain reaches at least one Strategy or Principle
+- [ ] WHY chain reaches at least one Product Thesis or Principle
 - [ ] Parent containers are included (Zone for Room, Room for Structure, etc.)
 
 If any mandatory category is missing, search specifically for it.
@@ -126,9 +126,9 @@ When your task is about the library itself (not assembling context for implement
 
 Additional references: `.claude/skills/conan/rubrics.md`, `.claude/skills/conan/grade-computation.md`
 
-**Build sequence:** Source Assessment → Inventory → Sam builds Standards → Spot-Check → Sam builds Strategy/Principles → Spot-Check → Sam builds product-layer cards → Grade → Fix cycle → **Downstream Sync**
+**Build sequence:** Source Assessment → Inventory → Sam builds Standards → Spot-Check → Sam builds Product Thesis/Principles → Spot-Check → Sam builds product-layer cards → Grade → Fix cycle → **Downstream Sync**
 
-**Assessment sequence:** Source Alignment → Inventory Reconciliation → Standards Health → Strategy/Principle Health → Product Layer Sampling → Cascade Analysis → **Downstream Sync**
+**Assessment sequence:** Source Alignment → Inventory Reconciliation → Standards Health → Product Thesis/Principle Health → Product Layer Sampling → Cascade Analysis → **Downstream Sync**
 
 **Auto-trigger rule:** After completing ANY maintenance job that changes library structure (new types, renames, folder changes, bulk card creation/deletion, template changes), ALWAYS run Job 9 (Downstream Sync) as the final step. Do not wait for the human to ask. This prevents meta-file drift.
 
@@ -154,7 +154,7 @@ Additional references: `.claude/skills/conan/rubrics.md`, `.claude/skills/conan/
 
 **Step 1: Is this about WHY we build?**
 
-- Guiding philosophy (a bet) → Strategy
+- Guiding philosophy (a bet) → Product Thesis
 - Judgment guidance (a rule of thumb) → Principle
 - Testable spec (concrete rules) → Standard
 
@@ -217,7 +217,7 @@ Apply IN ORDER. Each gate catches a common error pattern.
 | ----- | ---------------------------------------------------------- |
 | WHAT  | Standalone definition, no links needed to understand       |
 | WHERE | 3+ contextualized links, conformance links where obligated |
-| WHY   | Strategy/Principle link + driver                           |
+| WHY   | Product Thesis/Principle link + driver                     |
 | WHEN  | Temporal status or explicit N/A                            |
 | HOW   | Sufficient for builder to implement                        |
 
@@ -272,7 +272,7 @@ Commentary only below B. One sentence max. Rage through word choice, not volume.
 
 The Context Library lives at `docs/context-library/` with this structure:
 
-- `/rationale/` — Strategies, Principles, Standards (WHY layer)
+- `/rationale/` — Product Theses, Principles, Standards (WHY layer)
 - `/product/` — Zones, Rooms, Overlays, Structures, Components, Artifacts, Capabilities, Primitives, Systems, Agents (WHAT layer)
 - `/experience/` — Loops, Journeys, Aesthetics, Dynamics (experience layer — how the product feels over time)
 - `/temporal/` — Decision, Initiative, Future cards

--- a/.claude/agents/sam.md
+++ b/.claude/agents/sam.md
@@ -85,7 +85,7 @@ Hand off to Conan
 | Type              | Folder                    |
 | ----------------- | ------------------------- |
 | Foundation / Need | `/rationale/` (flat)      |
-| Strategy          | `/rationale/strategies/`  |
+| Product Thesis    | `/rationale/product-thesis/` |
 | Principle         | `/rationale/principles/`  |
 | Standard          | `/rationale/standards/`   |
 | Zone              | `/product/zones/`         |
@@ -124,7 +124,7 @@ This ensures every card you build has correct links, proper containment, and com
 5. **Flag, don't guess.** Unclear type? Flag for human judgment.
 6. **Self-check before handoff.** Catch obvious stuff before Conan does.
 7. **Keep it brief.** "Done: 5 cards. Flagged: 2. Ready for Conan."
-8. **Respect the two-layer split.** Strategies, Principles, and Standards go in `/rationale/`. Product cards go in `/product/`.
+8. **Respect the two-layer split.** Product Theses, Principles, and Standards go in `/rationale/`. Product cards go in `/product/`.
 
 ## Reference Files
 

--- a/.claude/agents/sam.md
+++ b/.claude/agents/sam.md
@@ -82,27 +82,27 @@ Hand off to Conan
 
 ## Library Organization
 
-| Type              | Folder                    |
-| ----------------- | ------------------------- |
-| Foundation / Need | `/rationale/` (flat)      |
+| Type              | Folder                       |
+| ----------------- | ---------------------------- |
+| Foundation / Need | `/rationale/` (flat)         |
 | Product Thesis    | `/rationale/product-thesis/` |
-| Principle         | `/rationale/principles/`  |
-| Standard          | `/rationale/standards/`   |
-| Zone              | `/product/zones/`         |
-| Room              | `/product/rooms/`         |
-| Overlay           | `/product/overlays/`      |
-| Structure         | `/product/structures/`    |
-| Component         | `/product/components/`    |
-| Artifact          | `/product/artifacts/`     |
-| Capability        | `/product/capabilities/`  |
-| Primitive         | `/product/primitives/`    |
-| System            | `/product/systems/`       |
-| Agent             | `/product/agents/`        |
-| Prompt            | `/product/prompts/`       |
-| Loop              | `/experience/loops/`      |
-| Journey           | `/experience/journeys/`   |
-| Aesthetic         | `/experience/aesthetics/` |
-| Dynamic           | `/experience/dynamics/`   |
+| Principle         | `/rationale/principles/`     |
+| Standard          | `/rationale/standards/`      |
+| Zone              | `/product/zones/`            |
+| Room              | `/product/rooms/`            |
+| Overlay           | `/product/overlays/`         |
+| Structure         | `/product/structures/`       |
+| Component         | `/product/components/`       |
+| Artifact          | `/product/artifacts/`        |
+| Capability        | `/product/capabilities/`     |
+| Primitive         | `/product/primitives/`       |
+| System            | `/product/systems/`          |
+| Agent             | `/product/agents/`           |
+| Prompt            | `/product/prompts/`          |
+| Loop              | `/experience/loops/`         |
+| Journey           | `/experience/journeys/`      |
+| Aesthetic         | `/experience/aesthetics/`    |
+| Dynamic           | `/experience/dynamics/`      |
 
 ## Navigating the Library
 

--- a/.claude/skills/conan/job-audit.md
+++ b/.claude/skills/conan/job-audit.md
@@ -14,7 +14,7 @@ Audit ≠ Grading. Card can score A and still fail audit if misclassified.
 
    ```
    Card: [Name]
-   Step 1: WHY question? → Strategy/Principle/Standard
+   Step 1: WHY question? → Product Thesis/Principle/Standard
    Step 2: WHAT + Builders interact?
      - Navigate TO it? Top-level → Zone. Nested → Room.
      - Persistent across zones? → Overlay

--- a/.claude/skills/conan/job-grade.md
+++ b/.claude/skills/conan/job-grade.md
@@ -8,7 +8,7 @@
 
 1. **Grade each card section by section** (see rubrics.md)
    - WHAT: Standalone? Specific? Complete?
-   - WHY: Strategy linked? Rationale? Driver? **Apply Trace Test.**
+   - WHY: Product Thesis linked? Rationale? Driver? **Apply Trace Test.**
    - WHERE: 3+ links? All contextualized? Bidirectional? **Conformance present?**
    - HOW: Sufficient for builder?
    - WHEN: (Vision Capture) Section exists with status marker?

--- a/.claude/skills/conan/job-health-check.md
+++ b/.claude/skills/conan/job-health-check.md
@@ -75,9 +75,9 @@ Standards without conforming cards: [list]
 Standards missing anti-examples: [list]
 ```
 
-### Phase 4: Strategy/Principle Health
+### Phase 4: Product Thesis/Principle Health
 
-Spot-check ALL Strategy and Principle notes.
+Spot-check ALL Product Thesis and Principle notes.
 
 | Check         | Pass Criteria                                   |
 | ------------- | ----------------------------------------------- |
@@ -89,7 +89,7 @@ Spot-check ALL Strategy and Principle notes.
 **Output:**
 
 ```
-## Strategy/Principle Health
+## Product Thesis/Principle Health
 
 | Card | WHAT | WHY | Anti-patterns | Downstream | Verdict |
 |------|------|-----|---------------|------------|---------|
@@ -135,7 +135,7 @@ For weak product-layer cards, trace upstream:
 
 ```
 Card weak on WHY?
-    └─ Check linked Strategy/Principle
+    └─ Check linked Product Thesis/Principle
         └─ Stub? → Upstream fix
         └─ Substantive? → Card-level fix
 
@@ -174,7 +174,7 @@ Scope: [full library / zone]
 |-------|--------|-----------|
 | Source Alignment | [Good/Drift/Gap] | |
 | Standards | [n]/[total] pass | |
-| Strategy/Principles | [n]/[total] pass | |
+| Product Thesis/Principles | [n]/[total] pass | |
 | Product Layer (sampled) | [grade] | |
 
 Overall: [Healthy / Needs Work / Critical]
@@ -188,7 +188,7 @@ Overall: [Healthy / Needs Work / Critical]
 ## Phase 3: Standards
 [details]
 
-## Phase 4: Strategy/Principles
+## Phase 4: Product Thesis/Principles
 [details]
 
 ## Phase 5: Product Layer
@@ -220,7 +220,7 @@ Overall: [Healthy / Needs Work / Critical]
 
 | Level      | Definition                                                                           |
 | ---------- | ------------------------------------------------------------------------------------ |
-| Healthy    | >80% Standards pass, >80% Strategy/Principles pass, Product layer sample averages B+ |
+| Healthy    | >80% Standards pass, >80% Product Thesis/Principles pass, Product layer sample averages B+ |
 | Needs Work | 60-80% pass rates, or Product layer sample averages B- to C+                         |
 | Critical   | <60% pass rates, or Product layer sample below C                                     |
 
@@ -228,6 +228,6 @@ Overall: [Healthy / Needs Work / Critical]
 
 - Upstream before downstream — always
 - Distinguish root causes from symptoms
-- Standards and Strategy gaps hurt most — prioritize finding them
+- Standards and Product Thesis gaps hurt most — prioritize finding them
 - Sample product-layer cards strategically — high-link cards reveal more
 - Anti-patterns gaps are fixable — flag but don't panic

--- a/.claude/skills/conan/job-health-check.md
+++ b/.claude/skills/conan/job-health-check.md
@@ -218,11 +218,11 @@ Overall: [Healthy / Needs Work / Critical]
 
 ## Health Levels
 
-| Level      | Definition                                                                           |
-| ---------- | ------------------------------------------------------------------------------------ |
+| Level      | Definition                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------ |
 | Healthy    | >80% Standards pass, >80% Product Thesis/Principles pass, Product layer sample averages B+ |
-| Needs Work | 60-80% pass rates, or Product layer sample averages B- to C+                         |
-| Critical   | <60% pass rates, or Product layer sample below C                                     |
+| Needs Work | 60-80% pass rates, or Product layer sample averages B- to C+                               |
+| Critical   | <60% pass rates, or Product layer sample below C                                           |
 
 ## Principles
 

--- a/.claude/skills/conan/job-inventory.md
+++ b/.claude/skills/conan/job-inventory.md
@@ -30,7 +30,7 @@
 
 9. **Determine build order** — Sequence for Sam to build:
    - Standards first (they constrain everything)
-   - Strategy/Principles next (WHY upstream)
+   - Product Thesis/Principles next (WHY upstream)
    - Systems next (cross-cutting mechanisms)
    - Zones/Rooms (most-depended-on first)
    - Overlays, Structures, Artifacts, Capabilities
@@ -51,7 +51,7 @@ Date: [date]
 | Card | Source | Status | Classification Rationale |
 |------|--------|--------|-------------------------|
 
-### Strategy/Principles ([count])
+### Product Thesis/Principles ([count])
 | Card | Source | Status | Classification Rationale |
 |------|--------|--------|-------------------------|
 
@@ -111,7 +111,7 @@ Build in this sequence (most-depended-on first):
 | Order | Card | Rationale |
 |-------|------|-----------|
 
-### Phase 2: Strategy/Principles
+### Phase 2: Product Thesis/Principles
 | Order | Card | Rationale |
 |-------|------|-----------|
 

--- a/.claude/skills/conan/job-release-planning.md
+++ b/.claude/skills/conan/job-release-planning.md
@@ -11,7 +11,7 @@
 Every release advances LifeBuild along three independent strategic bets, each with a maturity ladder:
 
 **Plank 1 — Spatial Visibility** (serves Autonomy)
-Source: `docs/context-library/rationale/strategies/Strategy - Spatial Visibility.md`
+Source: `docs/context-library/rationale/product-thesis/Product Thesis - Spatial Visibility.md`
 
 | Level | Name                    | What It Is                                |
 | ----- | ----------------------- | ----------------------------------------- |
@@ -22,7 +22,7 @@ Source: `docs/context-library/rationale/strategies/Strategy - Spatial Visibility
 | 4     | Hybrid Physical/Digital | AR integration                            |
 
 **Plank 2 — Superior Process** (serves Competence)
-Source: `docs/context-library/rationale/strategies/Strategy - Superior Process.md`
+Source: `docs/context-library/rationale/product-thesis/Product Thesis - Superior Process.md`
 
 | Level | Name                  | What It Is                                |
 | ----- | --------------------- | ----------------------------------------- |
@@ -36,7 +36,7 @@ Source: `docs/context-library/rationale/strategies/Strategy - Superior Process.m
 | 7     | Full Orchestrated     | Defined roles, communication protocols    |
 
 **Plank 3 — AI as Teammates** (serves Relatedness)
-Source: `docs/context-library/rationale/strategies/Strategy - AI as Teammates.md`
+Source: `docs/context-library/rationale/product-thesis/Product Thesis - AI as Teammates.md`
 
 | Level | Name                   | What It Is                                      |
 | ----- | ---------------------- | ----------------------------------------------- |
@@ -90,10 +90,10 @@ Releases are grouped into thematic arcs. Each arc has a narrative theme and a pr
 
 2. **Read adjacent releases** — Read the release before (what the builder can do) and after (what they need to be able to do). The new release bridges that gap.
 
-3. **Read the three strategy cards** — Always re-read the maturity ladders to anchor ladder positions:
-   - `docs/context-library/rationale/strategies/Strategy - Spatial Visibility.md`
-   - `docs/context-library/rationale/strategies/Strategy - Superior Process.md`
-   - `docs/context-library/rationale/strategies/Strategy - AI as Teammates.md`
+3. **Read the three plank cards** — Always re-read the maturity ladders to anchor ladder positions:
+   - `docs/context-library/rationale/product-thesis/Product Thesis - Spatial Visibility.md`
+   - `docs/context-library/rationale/product-thesis/Product Thesis - Superior Process.md`
+   - `docs/context-library/rationale/product-thesis/Product Thesis - AI as Teammates.md`
 
 4. **Set ladder positions** — Where does each bet stand BEFORE this release? Where should it stand AFTER? Use the maturity ladder levels.
 
@@ -323,6 +323,6 @@ After a release ships, convert the planning card to retrospective format by addi
 
 - Release cards live at: `docs/context-library/releases/`
 - Naming: `Release - [Title].md` (e.g., `Release - The Campfire.md`)
-- Strategy cards: `docs/context-library/rationale/strategies/Strategy - *.md`
+- Product Thesis cards: `docs/context-library/rationale/product-thesis/Product Thesis - *.md`
 - Existing releases: Read all files in `docs/context-library/releases/` before writing new ones
 - Builder journey phases: `docs/context-library/experience/journeys/Journey - Sanctuary Progression.md`

--- a/.claude/skills/conan/job-spot-check.md
+++ b/.claude/skills/conan/job-spot-check.md
@@ -1,8 +1,8 @@
 # Job 2.5: Spot-Check
 
-**Purpose:** Verify upstream cards (Standards, Strategy, Principles) before dependent product-layer cards are built.
+**Purpose:** Verify upstream cards (Standards, Product Thesis, Principles) before dependent product-layer cards are built.
 
-**Trigger:** After Sam builds Standards or Strategy/Principle notes, before building product-layer cards (Rooms, Overlays, Structures, etc.).
+**Trigger:** After Sam builds Standards or Product Thesis/Principle notes, before building product-layer cards (Rooms, Overlays, Structures, etc.).
 
 Spot-Check gates product-layer builds. Catches upstream gaps before they cascade.
 
@@ -10,7 +10,7 @@ Spot-Check gates product-layer builds. Catches upstream gaps before they cascade
 
 1. **Identify cards to check**
    - All Standards just built
-   - All Strategy notes just built or enriched
+   - All Product Thesis notes just built or enriched
    - All Principle notes just built or enriched
 
 2. **Apply abbreviated rubric**
@@ -23,7 +23,7 @@ Spot-Check gates product-layer builds. Catches upstream gaps before they cascade
    | HOW | Contains actual spec (values, rules, thresholds) |
    | Anti-example | Includes what violation looks like |
 
-   Strategy/Principle:
+   Product Thesis/Principle:
    | Check | Pass Criteria |
    |-------|---------------|
    | WHAT | Clear statement, not placeholder |
@@ -57,7 +57,7 @@ Cards checked: [n]
 |------|------|-----|-----|---------|---------|
 | [name] | ✓/✗ | ✓/✗ | ✓/✗ | ✓/✗ | PASS/FIX/ESCALATE |
 
-## Strategy/Principles
+## Product Thesis/Principles
 
 | Card | WHAT | WHY | Anti-pattern | Verdict |
 |------|------|-----|--------------|---------|
@@ -82,7 +82,7 @@ Cards checked: [n]
 - Contains table, list, or explicit values? → Pass
 - Vague guidance only? → Fail
 
-**Strategy - WHY Check:**
+**Product Thesis - WHY Check:**
 
 - Explains reasoning ("because...", "we believe...")? → Pass
 - Just asserts ("X is important")? → Fail

--- a/.claude/skills/conan/rubrics.md
+++ b/.claude/skills/conan/rubrics.md
@@ -23,7 +23,7 @@ Criteria: Product Thesis linked (with explanation), Rationale present, Driver tr
 | Grade | Criteria                                               |
 | ----- | ------------------------------------------------------ |
 | A     | Full causal chain. Alternatives/tensions acknowledged. |
-| B     | Product Thesis + driver + rationale. No tensions.            |
+| B     | Product Thesis + driver + rationale. No tensions.      |
 | C     | Thin explanation OR missing driver.                    |
 | D     | Vague strategy reference, no real rationale.           |
 | F     | Empty or no strategic connection.                      |

--- a/.claude/skills/conan/rubrics.md
+++ b/.claude/skills/conan/rubrics.md
@@ -18,19 +18,19 @@ Failure example: "The settings for Bronze mode." → F (pointer, not definition)
 
 ## WHY
 
-Criteria: Strategy linked (with explanation), Rationale present, Driver traced
+Criteria: Product Thesis linked (with explanation), Rationale present, Driver traced
 
 | Grade | Criteria                                               |
 | ----- | ------------------------------------------------------ |
 | A     | Full causal chain. Alternatives/tensions acknowledged. |
-| B     | Strategy + driver + rationale. No tensions.            |
+| B     | Product Thesis + driver + rationale. No tensions.            |
 | C     | Thin explanation OR missing driver.                    |
 | D     | Vague strategy reference, no real rationale.           |
 | F     | Empty or no strategic connection.                      |
 
 **Trace Test:** Follow strategy links. If upstream is stub → penalize downstream card.
 
-Failure example: "Strategy: [[Visual Work]]" → D (naked link)
+Failure example: "Product Thesis: [[Visual Work]]" → D (naked link)
 
 ## WHERE
 
@@ -117,7 +117,7 @@ Flag during grading, don't halt. Complete grade + note AUDIT SIGNAL.
 - WHY focuses on belief/evidence, not driver
 - Must have "What Violating This Looks Like" section
 
-**Strategies:**
+**Product Theses:**
 
 - Must have "What Violating This Looks Like" section
 - WHY must have reasoning, not just assertion

--- a/.claude/skills/context-briefing/SKILL.md
+++ b/.claude/skills/context-briefing/SKILL.md
@@ -18,7 +18,7 @@ Location: `docs/context-library/`
 
 | Layer     | Folder                   | Types                        |
 | --------- | ------------------------ | ---------------------------- |
-| Rationale | `/rationale/strategies/` | Strategy (3)                 |
+| Rationale | `/rationale/product-thesis/` | Product Thesis (5)          |
 | Rationale | `/rationale/principles/` | Principle (15)               |
 | Rationale | `/rationale/standards/`  | Standard (16)                |
 | Product   | `/product/zones/`        | Zone (3)                     |
@@ -39,7 +39,7 @@ Every card has 5 dimensions:
 
 - **WHAT** — Standalone definition
 - **WHERE** — Ecosystem relationships via `[[wikilinks]]`
-- **WHY** — Strategic rationale (links to Strategies/Principles)
+- **WHY** — Strategic rationale (links to Product Theses/Principles)
 - **WHEN** — Build phase, implementation status, reality notes
 - **HOW** — Implementation guidance, examples, anti-patterns
 
@@ -74,7 +74,7 @@ See `protocol.md` for the CONTEXT_BRIEFING.md format.
 ## Quick Reference: Upstream Chain
 
 ```
-Strategy (WHY we care)
+Product Thesis (WHY we care)
     ↓ generates
 Principle (judgment guidance)
     ↓ implemented by
@@ -89,4 +89,4 @@ Primitive (core data entity)
 Agent (AI team member)
 ```
 
-Every product-layer card should trace back to at least one Strategy via its WHY chain. If it can't, that's a gap worth noting.
+Every product-layer card should trace back to at least one Product Thesis via its WHY chain. If it can't, that's a gap worth noting.

--- a/.claude/skills/context-briefing/SKILL.md
+++ b/.claude/skills/context-briefing/SKILL.md
@@ -16,22 +16,22 @@ Location: `docs/context-library/`
 
 ~100 markdown cards organized by type:
 
-| Layer     | Folder                   | Types                        |
-| --------- | ------------------------ | ---------------------------- |
-| Rationale | `/rationale/product-thesis/` | Product Thesis (5)          |
-| Rationale | `/rationale/principles/` | Principle (15)               |
-| Rationale | `/rationale/standards/`  | Standard (16)                |
-| Product   | `/product/zones/`        | Zone (3)                     |
-| Product   | `/product/rooms/`        | Room (7)                     |
-| Product   | `/product/overlays/`     | Overlay (1)                  |
-| Product   | `/product/structures/`   | Structure (2)                |
-| Product   | `/product/components/`   | Component (5)                |
-| Product   | `/product/artifacts/`    | Artifact (2)                 |
-| Product   | `/product/capabilities/` | Capability (7)               |
-| Product   | `/product/primitives/`   | Primitive (3)                |
-| Product   | `/product/systems/`      | System (15)                  |
-| Product   | `/product/agents/`       | Agent (14)                   |
-| Temporal  | `/temporal/`             | Decision, Initiative, Future |
+| Layer     | Folder                       | Types                        |
+| --------- | ---------------------------- | ---------------------------- |
+| Rationale | `/rationale/product-thesis/` | Product Thesis (5)           |
+| Rationale | `/rationale/principles/`     | Principle (15)               |
+| Rationale | `/rationale/standards/`      | Standard (16)                |
+| Product   | `/product/zones/`            | Zone (3)                     |
+| Product   | `/product/rooms/`            | Room (7)                     |
+| Product   | `/product/overlays/`         | Overlay (1)                  |
+| Product   | `/product/structures/`       | Structure (2)                |
+| Product   | `/product/components/`       | Component (5)                |
+| Product   | `/product/artifacts/`        | Artifact (2)                 |
+| Product   | `/product/capabilities/`     | Capability (7)               |
+| Product   | `/product/primitives/`       | Primitive (3)                |
+| Product   | `/product/systems/`          | System (15)                  |
+| Product   | `/product/agents/`           | Agent (14)                   |
+| Temporal  | `/temporal/`                 | Decision, Initiative, Future |
 
 ## Card Anatomy
 

--- a/.claude/skills/context-briefing/protocol.md
+++ b/.claude/skills/context-briefing/protocol.md
@@ -112,12 +112,12 @@ SEARCH: Grep for "[terms]" in docs/context-library/
 
 ### Search Techniques
 
-| Need                             | Technique                                                   |
-| -------------------------------- | ----------------------------------------------------------- |
-| Find a card by name              | `Glob` for `**/[Type] - [Name].md`                          |
-| Find cards about a topic         | `Grep` for topic terms across `docs/context-library/`       |
-| Find cards in a dimension        | `Grep` for content under `## WHY:` or `## HOW:` headers     |
-| Find cards that reference a card | `Grep` for `[[Card Name]]` across the library               |
+| Need                             | Technique                                                         |
+| -------------------------------- | ----------------------------------------------------------------- |
+| Find a card by name              | `Glob` for `**/[Type] - [Name].md`                                |
+| Find cards about a topic         | `Grep` for topic terms across `docs/context-library/`             |
+| Find cards in a dimension        | `Grep` for content under `## WHY:` or `## HOW:` headers           |
+| Find cards that reference a card | `Grep` for `[[Card Name]]` across the library                     |
 | Follow a WHY chain upstream      | Read card → follow `[[Principle -` and `[[Product Thesis -` links |
 
 ### Loop Prevention

--- a/.claude/skills/context-briefing/protocol.md
+++ b/.claude/skills/context-briefing/protocol.md
@@ -118,7 +118,7 @@ SEARCH: Grep for "[terms]" in docs/context-library/
 | Find cards about a topic         | `Grep` for topic terms across `docs/context-library/`       |
 | Find cards in a dimension        | `Grep` for content under `## WHY:` or `## HOW:` headers     |
 | Find cards that reference a card | `Grep` for `[[Card Name]]` across the library               |
-| Follow a WHY chain upstream      | Read card → follow `[[Principle -` and `[[Strategy -` links |
+| Follow a WHY chain upstream      | Read card → follow `[[Principle -` and `[[Product Thesis -` links |
 
 ### Loop Prevention
 
@@ -187,7 +187,7 @@ When mapping relationships in the briefing, use these edge types:
 | `constrained-by`   | Must conform to this        | Component constrained-by Standard |
 | `contains`         | Parent-child spatial        | Zone contains Room                |
 | `invokes`          | Triggers this workflow      | Room invokes Capability           |
-| `extends`          | Builds on this              | Principle extends Strategy        |
+| `extends`          | Builds on this              | Principle extends Product Thesis  |
 | `coordinates-with` | Peer relationship           | Agent coordinates-with Agent      |
 | `operates-on`      | Acts on this data           | Capability operates-on Primitive  |
 | `manages`          | Oversees lifecycle of       | Agent manages Artifact            |

--- a/.claude/skills/context-briefing/retrieval-profiles.md
+++ b/.claude/skills/context-briefing/retrieval-profiles.md
@@ -341,20 +341,20 @@ Dynamics are about HOW the system responds to emergent behavior.
 
 Quick reference for what MUST be included regardless of scoring:
 
-| Target Type | Mandatory                                                 |
-| ----------- | --------------------------------------------------------- |
+| Target Type | Mandatory                                                       |
+| ----------- | --------------------------------------------------------------- |
 | System      | 1+ Product Thesis, all anti-patterns, all affected Capabilities |
-| Component   | Parent Structure/Room, all conforming Standards           |
-| Room        | Parent Zone, resident Agent (if exists)                   |
+| Component   | Parent Structure/Room, all conforming Standards                 |
+| Room        | Parent Zone, resident Agent (if exists)                         |
 | Zone        | All contained Rooms, 1+ Product Thesis                          |
-| Structure   | Parent Room, all conforming Standards                     |
-| Capability  | 1+ Room, all affected Artifacts                           |
+| Structure   | Parent Room, all conforming Standards                           |
+| Capability  | 1+ Room, all affected Artifacts                                 |
 | Agent       | Home Room, all managed Artifacts, 1+ Product Thesis             |
-| Prompt      | Parent Agent (complete)                                   |
-| Overlay     | All visible Zones, all conforming Standards               |
-| Primitive   | All Rooms that serve it, all operating Capabilities       |
-| Artifact    | Host Room, all using Capabilities                         |
-| Loop        | All composing Capabilities, all involved Rooms            |
-| Journey     | All Loops engaged, all guiding Agents                     |
-| Aesthetic   | All contexts where feeling applies                        |
-| Dynamic     | All contributing Systems, agent responses                 |
+| Prompt      | Parent Agent (complete)                                         |
+| Overlay     | All visible Zones, all conforming Standards                     |
+| Primitive   | All Rooms that serve it, all operating Capabilities             |
+| Artifact    | Host Room, all using Capabilities                               |
+| Loop        | All composing Capabilities, all involved Rooms                  |
+| Journey     | All Loops engaged, all guiding Agents                           |
+| Aesthetic   | All contexts where feeling applies                              |
+| Dynamic     | All contributing Systems, agent responses                       |

--- a/.claude/skills/context-briefing/retrieval-profiles.md
+++ b/.claude/skills/context-briefing/retrieval-profiles.md
@@ -13,14 +13,14 @@ Type-specific instructions for assembling context briefings. Each profile descri
 **Always include:**
 
 - The System card itself (full content)
-- At least 1 governing Strategy (follow WHY links)
+- At least 1 governing Product Thesis (follow WHY links)
 - All Principles referenced in the card's WHY section
 - All Capabilities that invoke this system — `Grep` for the system name across `docs/context-library/product/capabilities/`
 - All Rooms where this system is visible — `Grep` for the system name across `docs/context-library/product/rooms/`
 - Any Standards this system must conform to
 
 **Traversal depth:** 3 hops upstream via wikilinks.
-Read the card → follow its `[[links]]` → follow THOSE cards' `[[links]]` → one more hop for Strategy/Principle chains.
+Read the card → follow its `[[links]]` → follow THOSE cards' `[[links]]` → one more hop for Product Thesis/Principle chains.
 
 **Dimension priority:** WHY (high) > WHERE (high) > HOW (medium) > WHAT (low).
 When summarizing supporting cards, preserve WHY and WHERE content. Compress HOW to key points.
@@ -86,7 +86,7 @@ Rooms are relationship-heavy — WHERE context (what connects to what) is critic
 - The Zone card itself (full content)
 - All Rooms contained in this Zone — `Glob` for cards referencing this zone
 - Visible Overlays — `Grep` for the zone name across `docs/context-library/product/overlays/`
-- Governing Strategies (at least 1)
+- Governing Product Theses (at least 1)
 - Adjacent Zones for navigation context
 
 **Traversal depth:** 2 hops. Zone → contained Rooms → their key elements.
@@ -151,7 +151,7 @@ Capabilities are about connections and workflows — WHERE it happens and HOW it
 - Room where this Artifact is edited
 - Capabilities that use this Artifact
 - Primitives this Artifact contains
-- Governing Strategy (at least 1)
+- Governing Product Thesis (at least 1)
 
 **Traversal depth:** 2 hops. Artifact → Room and Artifact → Capabilities.
 
@@ -195,10 +195,10 @@ Overlays are cross-zone — WHERE they appear and HOW they behave across context
 - All Capabilities available to this Agent — `Grep` for agent name across `docs/context-library/product/capabilities/`
 - Artifacts this Agent manages — check WHERE section
 - Coordinating Agents (agents this one hands off to or coordinates with)
-- Full WHY chain — at least 1 Strategy, all referenced Principles
+- Full WHY chain — at least 1 Product Thesis, all referenced Principles
 - Any Prompts that implement this Agent — `Glob` for `docs/context-library/product/prompts/Prompt - [Agent Name]*.md`
 
-**Traversal depth:** 3 hops. Agents are highly connected — Room, Capabilities, Artifacts, Strategy chain.
+**Traversal depth:** 3 hops. Agents are highly connected — Room, Capabilities, Artifacts, Product Thesis chain.
 
 **Dimension priority:** WHY (high) > WHERE (high) > HOW (medium) > WHAT (low).
 Agent alignment is strategic — WHY they exist and WHERE they fit matters as much as implementation.
@@ -261,7 +261,7 @@ Primitives are the data backbone — WHERE they're used throughout the product i
 - Parent Loop (if nested) and child Loops (if containing)
 - Journey this Loop advances (if any)
 - Agents who participate
-- At least 1 Strategy from the WHY section
+- At least 1 Product Thesis from the WHY section
 
 **Traversal depth:** 2 hops. Loops connect Rooms, Capabilities, and Agents.
 
@@ -284,7 +284,7 @@ Loops are about the cycle — HOW it flows and WHERE it happens.
 - Agents who guide through phases
 - Systems that support progression
 - Capabilities unlocked during progression
-- At least 1 Strategy from the WHY section
+- At least 1 Product Thesis from the WHY section
 
 **Traversal depth:** 3 hops. Journeys span the full product.
 
@@ -343,13 +343,13 @@ Quick reference for what MUST be included regardless of scoring:
 
 | Target Type | Mandatory                                                 |
 | ----------- | --------------------------------------------------------- |
-| System      | 1+ Strategy, all anti-patterns, all affected Capabilities |
+| System      | 1+ Product Thesis, all anti-patterns, all affected Capabilities |
 | Component   | Parent Structure/Room, all conforming Standards           |
 | Room        | Parent Zone, resident Agent (if exists)                   |
-| Zone        | All contained Rooms, 1+ Strategy                          |
+| Zone        | All contained Rooms, 1+ Product Thesis                          |
 | Structure   | Parent Room, all conforming Standards                     |
 | Capability  | 1+ Room, all affected Artifacts                           |
-| Agent       | Home Room, all managed Artifacts, 1+ Strategy             |
+| Agent       | Home Room, all managed Artifacts, 1+ Product Thesis             |
 | Prompt      | Parent Agent (complete)                                   |
 | Overlay     | All visible Zones, all conforming Standards               |
 | Primitive   | All Rooms that serve it, all operating Capabilities       |

--- a/.claude/skills/context-briefing/task-modifiers.md
+++ b/.claude/skills/context-briefing/task-modifiers.md
@@ -81,10 +81,10 @@ How the type of task affects which dimensions to prioritize during context assem
 
 ## Quick Reference
 
-| Task Type    | Primary Dimensions  | Retrieval Width      | Upstream Depth        |
-| ------------ | ------------------- | -------------------- | --------------------- |
-| Feature      | WHERE, HOW          | Broad lateral        | Profile default       |
-| Bug fix      | HOW, WHEN           | Narrow + temporal    | Profile default       |
+| Task Type    | Primary Dimensions  | Retrieval Width      | Upstream Depth              |
+| ------------ | ------------------- | -------------------- | --------------------------- |
+| Feature      | WHERE, HOW          | Broad lateral        | Profile default             |
+| Bug fix      | HOW, WHEN           | Narrow + temporal    | Profile default             |
 | Refactor     | WHY, WHERE          | Broad + blast radius | Maximum (to Product Thesis) |
 | New          | WHY, HOW + siblings | Medium + patterns    | Profile default             |
 | Architecture | WHY, WHERE, WHEN    | Maximum              | Maximum (to Product Thesis) |

--- a/.claude/skills/context-briefing/task-modifiers.md
+++ b/.claude/skills/context-briefing/task-modifiers.md
@@ -45,7 +45,7 @@ How the type of task affects which dimensions to prioritize during context assem
 - **HOW** (low) — You're changing the HOW, so current HOW is less useful.
 - **WHEN** (normal) — Stability markers help — don't refactor evolving cards.
 
-**Retrieval adjustment:** Expand upstream. Follow the full WHY chain to Strategy level. Read anti-patterns carefully — "What Breaks This" lists are especially relevant during refactoring.
+**Retrieval adjustment:** Expand upstream. Follow the full WHY chain to Product Thesis level. Read anti-patterns carefully — "What Breaks This" lists are especially relevant during refactoring.
 
 ---
 
@@ -75,7 +75,7 @@ How the type of task affects which dimensions to prioritize during context assem
 - **WHEN** (high) — Stability matters. Don't change stable foundations without strong justification. Check what's evolving vs settled.
 - **HOW** (normal) — Current implementation matters less since you're changing it.
 
-**Retrieval adjustment:** Maximum upstream and lateral expansion. Use the full 3-hop depth. Read ALL related Strategies and Principles. Assess blast radius by `Grep`-ing for the concept name across the entire library — every match is something potentially affected.
+**Retrieval adjustment:** Maximum upstream and lateral expansion. Use the full 3-hop depth. Read ALL related Product Theses and Principles. Assess blast radius by `Grep`-ing for the concept name across the entire library — every match is something potentially affected.
 
 ---
 
@@ -85,6 +85,6 @@ How the type of task affects which dimensions to prioritize during context assem
 | ------------ | ------------------- | -------------------- | --------------------- |
 | Feature      | WHERE, HOW          | Broad lateral        | Profile default       |
 | Bug fix      | HOW, WHEN           | Narrow + temporal    | Profile default       |
-| Refactor     | WHY, WHERE          | Broad + blast radius | Maximum (to Strategy) |
-| New          | WHY, HOW + siblings | Medium + patterns    | Profile default       |
-| Architecture | WHY, WHERE, WHEN    | Maximum              | Maximum (to Strategy) |
+| Refactor     | WHY, WHERE          | Broad + blast radius | Maximum (to Product Thesis) |
+| New          | WHY, HOW + siblings | Medium + patterns    | Profile default             |
+| Architecture | WHY, WHERE, WHEN    | Maximum              | Maximum (to Product Thesis) |

--- a/.claude/skills/context-briefing/traversal.md
+++ b/.claude/skills/context-briefing/traversal.md
@@ -54,7 +54,7 @@ To find cards with specific WHY content:
 Grep: pattern="Spatial Visibility" path="docs/context-library/"
 ```
 
-This finds all cards that reference the Spatial Visibility strategy in any section.
+This finds all cards that reference the Spatial Visibility product thesis in any section.
 
 To narrow to a specific dimension header:
 
@@ -116,11 +116,11 @@ Follow the rationale hierarchy from a product card to its strategic foundation.
 ```
 1. Read the product card's WHY section
 2. Find [[Principle - ...]] links → Read those Principles
-3. In each Principle's WHY section, find [[Strategy - ...]] links → Read those Strategies
-4. Strategy is the top — stop here
+3. In each Principle's WHY section, find [[Product Thesis - ...]] links → Read those Product Theses
+4. Product Thesis is the top — stop here
 ```
 
-**Depth:** Usually 2-3 hops (Card → Principle → Strategy).
+**Depth:** Usually 2-3 hops (Card → Principle → Product Thesis).
 
 **Why this matters:** The WHY chain explains design intent. Without it, a builder can implement the WHAT correctly but violate the WHY.
 
@@ -174,7 +174,7 @@ Find everything affected by changing a card:
 3. **Standards:** WHERE section shows conforming Standards → Read those
 4. **Components:** `Grep` for "Kanban" across `product/components/` → Read matches
 5. **Primitives:** Card mentions `[[Primitive - Task]]` → Read it (task statuses are the filter values)
-6. **WHY chain:** WHY section links to a Principle → Read it → follow to Strategy
+6. **WHY chain:** WHY section links to a Principle → Read it → follow to Product Thesis
 7. **WHEN check:** Read WHEN sections of related cards for reality notes and divergences
 
 **Result:** ~8 cards covering the Structure, its Room, conforming Standards, displayed Primitive, and strategic rationale.
@@ -190,7 +190,7 @@ Find everything affected by changing a card:
 4. **Capabilities:** `Grep` for "System" across `product/capabilities/` → finds Capability - System Actions
 5. **Systems:** `Grep` for "System" across `product/systems/` → finds multiple
 6. **WHEN check:** Read WHEN sections of related cards for reality notes and implications
-7. **WHY chain:** Follow upstream to Strategy/Principle
+7. **WHY chain:** Follow upstream to Product Thesis/Principle
 8. **Standards:** Check what Standards define System properties
 
 **Result:** ~12 cards covering the Primitive, its associated Room and Capabilities, gap analysis from WHEN sections, and the strategic rationale for why Systems matter.

--- a/.claude/skills/sam/card-creation.md
+++ b/.claude/skills/sam/card-creation.md
@@ -77,12 +77,12 @@ Trace the rationale.
 ```markdown
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [how this implements it]
+- Product Thesis: [[Product Thesis]] — [how this implements it]
 - Principle: [[Principle]] — [what guidance it follows]
 - Driver: [[Signal/Pressure]] or Exploratory — [hypothesis]
 ```
 
-**Critical:** Check that strategy/principle notes exist and aren't stubs.
+**Critical:** Check that product thesis/principle notes exist and aren't stubs.
 
 If note doesn't exist → Create it now.
 If note is stub → Enrich it now.
@@ -138,7 +138,7 @@ Describe intended behavior with examples.
 - [ ] WHAT standalone?
 - [ ] 5+ links with context?
 - [ ] Conformance links where obligated?
-- [ ] Strategy note exists and is substantive?
+- [ ] Product Thesis note exists and is substantive?
 - [ ] WHEN has temporal status?
 - [ ] HOW has ≥2 examples?
 - [ ] HOW has ≥1 anti-example?
@@ -236,33 +236,39 @@ This is what builders read to know what to produce.
 
 ## Creating Supporting Notes
 
-### Strategy Note (5-10 minutes)
+### Product Thesis Note (5-10 minutes)
 
 Don't stub it. Conan traces these.
 
-**Strategy notes belong in `/rationale/strategies/`.**
+**Product Thesis notes belong in `/rationale/product-thesis/`.**
 
 ```markdown
-# Strategy - [Name]
+# Product Thesis - [Name]
 
-## WHAT: The Strategy
+## WHAT: The Thesis
 
-[One sentence articulating the bet.]
+[One sentence articulating the thesis.]
+
+Counter-thesis: [The strongest argument against this thesis.]
 
 ## WHERE: Ecosystem
 
+- Type: Product Thesis (Problem | Solution | Plank)
+- Parent: [[Product Thesis]] — [relationship to parent thesis]
 - Principles:
   - [[Principle]] — [what judgment guidance this generates]
 - Standards:
   - [[Standard]] — [what specifications this generates]
 - Zones:
   - [[Zone]] — [what product areas embody this]
-- Tensions:
-  - [[Strategy]] — [what other strategies this trades off against]
 
 ## WHY: Belief
 
 [Why we believe this — reasoning, not just assertion]
+
+## Validation Criteria
+
+[How to validate. Metrics, tests, targets, invalidation signals.]
 
 ## HOW: Application
 
@@ -276,10 +282,10 @@ Don't stub it. Conan traces these.
 
 ### Decision Heuristic
 
-[When facing a tradeoff, how does this strategy guide the choice?]
+[When facing a tradeoff, how does this thesis guide the choice?]
 ```
 
-**Minimum viable:** 150+ words with real reasoning in WHY. Anti-patterns required.
+**Minimum viable:** 150+ words with real reasoning in WHY. Validation criteria and anti-patterns required.
 
 ### Principle Note (5-10 minutes)
 
@@ -294,8 +300,8 @@ Don't stub it. Conan traces these.
 
 ## WHERE: Ecosystem
 
-- Strategy:
-  - [[Strategy]] — [what bet this serves]
+- Product Thesis:
+  - [[Product Thesis]] — [what bet this serves]
 - Standards:
   - [[Standard]] — [what specifications make this testable]
 - Governs:
@@ -367,7 +373,7 @@ For a zone with 10 cards:
 1. Read all source material (15-20 min)
 2. Create cards in build order:
    - Standards first (they constrain everything)
-   - Strategy/Principles next (WHY upstream)
+   - Product Thesis/Principles next (WHY upstream)
    - Systems next (cross-cutting mechanisms)
    - Zones/Rooms (most-depended-on first)
    - Overlays, Structures, Artifacts, Capabilities

--- a/.claude/skills/sam/decomposition.md
+++ b/.claude/skills/sam/decomposition.md
@@ -6,7 +6,7 @@ How to extract cards from source material. Use when Conan's inventory is sparse 
 
 ### Step 1: Is this about WHY we build?
 
-- Guiding philosophy (a bet) → **Strategy**
+- Guiding philosophy (a bet) → **Product Thesis**
 - Judgment guidance (a rule of thumb) → **Principle**
 - Testable spec (concrete rules, values, thresholds) → **Standard**
 

--- a/.claude/skills/sam/link-patterns.md
+++ b/.claude/skills/sam/link-patterns.md
@@ -190,18 +190,18 @@ Every card with a containment relationship must link to its parent.
 
 ---
 
-## Strategy/Principle Links (WHY Section)
+## Product Thesis/Principle Links (WHY Section)
 
 ```markdown
-- [[Strategy - X]] — this implements [principle] by [how]
+- [[Product Thesis - X]] — this implements [principle] by [how]
 - [[Principle - X]] — guidance driving [aspect] of this card
-- [[Strategy - X]] — philosophy behind [design choice]
+- [[Product Thesis - X]] — philosophy behind [design choice]
 ```
 
 **Examples:**
 
 ```markdown
-- [[Strategy - Visual Work]] — this implements visibility by showing queue state
+- [[Product Thesis - Visual Work]] — this implements visibility by showing queue state
 - [[Principle - Visual Recognition]] — guidance driving indicator design
 ```
 
@@ -267,7 +267,7 @@ Blocked by: [[X]] — can't proceed until [dependency resolved]
 | Depends on     | "provides", "must exist", "supplies"                              |
 | Depended on by | "uses this to", "displays", "built on"                            |
 | System         | "foundational mechanism", "cross-cutting"                         |
-| Strategy       | "implements [principle] by"                                       |
+| Product Thesis | "implements [principle] by"                                       |
 | Principle      | "guidance driving", "makes testable"                              |
 | Decision       | "key choice that", "decision determining"                         |
 | Temporal       | "supersedes", "enables", "blocked by"                             |

--- a/.claude/skills/sam/self-check.md
+++ b/.claude/skills/sam/self-check.md
@@ -62,12 +62,12 @@ If Standard doesn't exist yet → flag for creation.
 ### Folder Placement Check
 
 - [ ] **Card in correct layer?**
-  - Strategy, Principle, Standard → `/rationale/` subtree
+  - Product Thesis, Principle, Standard → `/rationale/` subtree
   - Zone, Room, Overlay, Structure, Component, Artifact, Capability, Primitive, System, Agent, Prompt → `/product/` subtree
 
 ### WHY Section (1 minute)
 
-- [ ] Strategy or Principle link present with explanation?
+- [ ] Product Thesis or Principle link present with explanation?
 - [ ] **Linked note exists?** (Check — don't link to nothing)
 - [ ] **Linked note is substantive?** (Not a stub)
 - [ ] Driver identified?
@@ -107,12 +107,12 @@ Different structure than product-layer cards.
 
 ---
 
-## Strategy/Principle Checklist
+## Product Thesis/Principle Checklist
 
 - [ ] WHY has reasoning, not just assertion?
 - [ ] **Has Anti-Patterns section?** (what violating this looks like)
 - [ ] Tensions documented?
-- [ ] **Filed in `/rationale/strategies/` or `/rationale/principles/`?** (not `/product/`)
+- [ ] **Filed in `/rationale/product-thesis/` or `/rationale/principles/`?** (not `/product/`)
 
 ---
 
@@ -148,12 +148,12 @@ After finishing a zone's cards:
 - [ ] All Standards have conforming cards linked?
 - [ ] All product-layer cards touching governed domains have conformance links?
 
-### Strategy/Principle Coverage
+### Product Thesis/Principle Coverage
 
-- [ ] Every linked strategy note exists?
-- [ ] Strategy notes have substance?
-- [ ] No orphan strategy notes?
-- [ ] **All Strategy/Principle notes have Anti-Patterns section?**
+- [ ] Every linked product thesis note exists?
+- [ ] Product Thesis notes have substance?
+- [ ] No orphan product thesis notes?
+- [ ] **All Product Thesis/Principle notes have Anti-Patterns section?**
 
 ### Examples & Anti-Patterns Coverage
 
@@ -201,13 +201,13 @@ appear in their Bronze queue each week..."
 ```markdown
 # The card says:
 
-Strategy: [[Strategy - Visual Work]] — implements visibility
+Product Thesis: [[Product Thesis - Visual Work]] — implements visibility
 
-# But the strategy note is just:
+# But the product thesis note is just:
 
 "Visual work is important."
 
-# Fix: Enrich the strategy note before handing off
+# Fix: Enrich the product thesis note before handing off
 ```
 
 **Missing conformance:**
@@ -230,7 +230,7 @@ Zone, System, Dependency, Dependency, Component
 # Good (spread across dimensions)
 
 Zone, System, Dependency (WHERE)
-Strategy, Decision (WHY)
+Product Thesis, Decision (WHY)
 Future enhancement (WHEN)
 ```
 
@@ -264,7 +264,7 @@ Future enhancement (WHEN)
 - Wrong: Applying glow to Bronze items (reserved for Gold/Silver)"
 ```
 
-**Strategy without anti-patterns:**
+**Product Thesis without anti-patterns:**
 
 ```markdown
 # Bad

--- a/docs/context-library/README.md
+++ b/docs/context-library/README.md
@@ -35,7 +35,7 @@ Without specification context, agents produce technically correct but contextual
 
 | Type       | Count | Purpose                                                   |
 | ---------- | ----- | --------------------------------------------------------- |
-| Strategies | 3     | Guiding philosophies — the bets we're making              |
+| Product Thesis | 5     | Problem thesis, solution thesis, and three strategic planks |
 | Principles | 15    | Judgment guidance — rules of thumb                        |
 | Standards  | 16    | Testable specifications — concrete rules cards conform to |
 

--- a/docs/context-library/README.md
+++ b/docs/context-library/README.md
@@ -33,11 +33,11 @@ Without specification context, agents produce technically correct but contextual
 
 ### Rationale (`/rationale/`) — WHY we build
 
-| Type       | Count | Purpose                                                   |
-| ---------- | ----- | --------------------------------------------------------- |
+| Type           | Count | Purpose                                                     |
+| -------------- | ----- | ----------------------------------------------------------- |
 | Product Thesis | 5     | Problem thesis, solution thesis, and three strategic planks |
-| Principles | 15    | Judgment guidance — rules of thumb                        |
-| Standards  | 16    | Testable specifications — concrete rules cards conform to |
+| Principles     | 15    | Judgment guidance — rules of thumb                          |
+| Standards      | 16    | Testable specifications — concrete rules cards conform to   |
 
 ### Product (`/product/`) — WHAT gets built
 

--- a/docs/context-library/communications/INVENTORY.md
+++ b/docs/context-library/communications/INVENTORY.md
@@ -79,7 +79,7 @@ These divisions are not parallel product features — they are distinct operatin
 | Strategy - Socialization as Infrastructure | Not built | The upstream bet: structured socialization across 1:1, Groups, and 1:Many is not a nice-to-have — it is infrastructure for a well-lived and well-operating company. The same rigor applied to software production applies to relationship and content production. Anchor for all communications cards.                                                 |
 | Strategy - Content Factory Model           | Not built | The bet that the software factory model (Decide → Shape → Make → Patch) applies directly to communications production. Separate factories per division, coordinated at the strategy level. The key insight from the source: AI is better trained at communications than at code, making this factory potentially more effective than the software one. |
 
-**Note:** [[Strategy - Superior Process]] and [[Strategy - AI as Teammates]] already exist and apply to communications. New cards should link to these rather than restate them.
+**Note:** [[Product Thesis - Superior Process]] and [[Product Thesis - AI as Teammates]] already exist and apply to communications. New cards should link to these rather than restate them.
 
 ### Principles (4)
 

--- a/docs/context-library/experience/aesthetics/Aesthetic - Accomplishment.md
+++ b/docs/context-library/experience/aesthetics/Aesthetic - Accomplishment.md
@@ -15,7 +15,7 @@
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Spatial Visibility]] — the map visibly reflects work done
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — the map visibly reflects work done
 - Principle: [[Principle - Visibility Creates Agency]] — visible accomplishment reinforces the builder's sense of capability
 - Driver: The builder needs evidence that their work matters — not abstract evidence (points, percentages) but tangible evidence (the map changed, the tile evolved, a new system generates tasks automatically). Accomplishment is the aesthetic that closes the effort-reward loop without extrinsic gamification.
 

--- a/docs/context-library/experience/aesthetics/Aesthetic - Being Known.md
+++ b/docs/context-library/experience/aesthetics/Aesthetic - Being Known.md
@@ -15,7 +15,7 @@
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - AI as Teammates]] — teammates know you; tools don't
+- Product Thesis: [[Product Thesis - AI as Teammates]] — teammates know you; tools don't
 - Principle: [[Principle - Earn Don't Interrogate]] — knowledge is earned through relationship, not extracted through forms
 - Driver: The difference between a tool and a teammate is that the teammate remembers. Being Known is the aesthetic that makes stewards feel like people you work with, not interfaces you use. It compounds over time — the longer the relationship, the more the builder feels understood.
 

--- a/docs/context-library/experience/aesthetics/Aesthetic - Clarity.md
+++ b/docs/context-library/experience/aesthetics/Aesthetic - Clarity.md
@@ -15,7 +15,7 @@
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Superior Process]] — clarity is the output of good process
+- Product Thesis: [[Product Thesis - Superior Process]] — clarity is the output of good process
 - Principle: [[Principle - Familiarity Over Function]] — priorities presented in a way that feels natural
 - Driver: The builder is overwhelmed not because they're incompetent but because modern life is genuinely complex. Clarity is the antidote — the feeling that complexity has been tamed into manageable, prioritized work. When the builder sees The Table with clear positions, the chaos recedes.
 

--- a/docs/context-library/experience/aesthetics/Aesthetic - Sanctuary.md
+++ b/docs/context-library/experience/aesthetics/Aesthetic - Sanctuary.md
@@ -16,7 +16,7 @@
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Spatial Visibility]] — the map IS the sanctuary; seeing it creates belonging
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — the map IS the sanctuary; seeing it creates belonging
 - Principle: [[Principle - Protect Transformation]] — the sanctuary protects what the builder is becoming
 - Driver: The builder needs to feel that this is a place, not an app. A place they built, a place that reflects their care, a place that persists whether they visit or not. The sanctuary aesthetic is what makes LifeBuild feel like home instead of a tool.
 

--- a/docs/context-library/experience/aesthetics/Aesthetic - Stewardship.md
+++ b/docs/context-library/experience/aesthetics/Aesthetic - Stewardship.md
@@ -14,7 +14,7 @@
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Superior Process]] — maintenance is sacred, not menial
+- Product Thesis: [[Product Thesis - Superior Process]] — maintenance is sacred, not menial
 - Principle: [[Principle - Visibility Creates Agency]] — visible territory state creates stewardship agency
 - Driver: Bronze work and system maintenance can feel like drudgery or like domain stewardship. The difference is aesthetic. When tending feels like walking your garden — noticing what's thriving, pruning what's overgrown, watering what's dry — it becomes satisfying rather than tedious. The Stewardship aesthetic transforms obligation into craft.
 

--- a/docs/context-library/experience/journeys/Journey - Builder Onboarding.md
+++ b/docs/context-library/experience/journeys/Journey - Builder Onboarding.md
@@ -27,7 +27,7 @@ From portal stranger to sanctuary resident -- the builder answers one question, 
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - AI as Teammates]] -- the builder's first experience IS the teammate relationship, delivered through action
+- Product Thesis: [[Product Thesis - AI as Teammates]] -- the builder's first experience IS the teammate relationship, delivered through action
 - Principle: [[Principle - First 72 Hours]] -- real progress within 72 hours
 - Principle: [[Principle - Action Before Explanation]] -- the builder acts before they understand
 - Principle: [[Principle - Compression and Release]] -- the portal creates the emotional foundation for everything that follows

--- a/docs/context-library/experience/journeys/Journey - Sanctuary Progression.md
+++ b/docs/context-library/experience/journeys/Journey - Sanctuary Progression.md
@@ -26,8 +26,8 @@ From survival to sovereignty — the builder progresses through three phases of 
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Superior Process]] — the process itself drives the progression
-- Strategy: [[Strategy - Spatial Visibility]] — the map IS the progression indicator
+- Product Thesis: [[Product Thesis - Superior Process]] — the process itself drives the progression
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — the map IS the progression indicator
 - Principle: [[Principle - Protect Transformation]] — Gold ventures shift from obligation to aspiration
 - Driver: The universal direction is that the ratio of capacity spent on chosen, meaningful work increases relative to capacity consumed by maintenance and obligation. Not tracked as a score — manifested as visual character, venture quality, and felt experience.
 

--- a/docs/context-library/experience/loops/Loop - Annual Reflection.md
+++ b/docs/context-library/experience/loops/Loop - Annual Reflection.md
@@ -23,7 +23,7 @@ The broadest engagement loop — once per year, the builder reviews how the sanc
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Superior Process]] — annual rhythm provides the longest-range perspective
+- Product Thesis: [[Product Thesis - Superior Process]] — annual rhythm provides the longest-range perspective
 - Principle: [[Principle - Visibility Creates Agency]] — seeing year-over-year change creates deep agency
 - Driver: Without a long-range view, builders lose the forest for the trees. The annual reflection is where the builder sees the full arc of their sanctuary's development — not individual tasks, but the shape of a life being intentionally built.
 

--- a/docs/context-library/experience/loops/Loop - Daily Check-In.md
+++ b/docs/context-library/experience/loops/Loop - Daily Check-In.md
@@ -22,7 +22,7 @@ The tightest engagement loop — the builder opens the app, surveys their active
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Superior Process]] — atomic work execution with immediate feedback
+- Product Thesis: [[Product Thesis - Superior Process]] — atomic work execution with immediate feedback
 - Principle: [[Principle - Visibility Creates Agency]] — tile updates make progress tangible
 - Driver: The builder needs to feel forward motion within a single session. The micro loop creates a tight feedback cycle: do a thing, see it reflected on the map.
 

--- a/docs/context-library/experience/loops/Loop - Expedition Cycle.md
+++ b/docs/context-library/experience/loops/Loop - Expedition Cycle.md
@@ -30,8 +30,8 @@ The core engagement loop — the builder assesses their sanctuary, commits to a 
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Superior Process]] — the expedition cycle IS the core process
-- Strategy: [[Strategy - AI as Teammates]] — stewards participate in every phase
+- Product Thesis: [[Product Thesis - Superior Process]] — the expedition cycle IS the core process
+- Product Thesis: [[Product Thesis - AI as Teammates]] — stewards participate in every phase
 - Principle: [[Principle - Plans Are Hypotheses]] — expeditions have bounded appetite, not unbounded commitments
 - Driver: The builder needs a rhythm of plan → execute → learn that compounds into life improvement. The expedition cycle creates that rhythm at a scale large enough for meaningful work, small enough for course correction.
 

--- a/docs/context-library/experience/loops/Loop - Sanctuary Walk.md
+++ b/docs/context-library/experience/loops/Loop - Sanctuary Walk.md
@@ -23,7 +23,7 @@ A meta-level survey loop — the builder scans the entire hex grid, identifies w
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Spatial Visibility]] — the map as holistic life view
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — the map as holistic life view
 - Principle: [[Principle - Visibility Creates Agency]] — seeing the whole domain creates agency to act
 - Driver: Builders need periodic zoomed-out awareness of their entire life landscape. The sanctuary walk prevents tunnel vision on active projects and surfaces neglected territories before they become crises.
 

--- a/docs/context-library/experience/loops/Loop - Seasonal Review.md
+++ b/docs/context-library/experience/loops/Loop - Seasonal Review.md
@@ -26,7 +26,7 @@ A macro engagement loop on a ~12-week cadence — four seasons per year, each wi
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy - Superior Process]] — seasonal rhythm prevents burnout and creates natural reflection points
+- Product Thesis: [[Product Thesis - Superior Process]] — seasonal rhythm prevents burnout and creates natural reflection points
 - Principle: [[Principle - Plans Are Hypotheses]] — seasonal boundaries are natural points to reassess direction
 - Driver: Builders need a rhythm longer than individual expeditions but shorter than a year. Seasons create natural cadence for planting, executing, harvesting, and resting — preventing the "always pushing" pattern that leads to capacity collapse.
 

--- a/docs/context-library/product/agents/Agent - Conan.md
+++ b/docs/context-library/product/agents/Agent - Conan.md
@@ -11,13 +11,13 @@ The builder's Librarian — a steward who records, remembers, and finds patterns
 - Manages: Completed projects, uprooted systems, historical data
 - Manages: Historical Charter versions
 - Coordinates with: [[Agent - Jarvis]] — feeds pattern analysis for strategic conversations; [[Agent - Marvin]] — provides project history, precedent data, and historical performance data for priority scoring
-- Implements: [[Strategy - AI as Teammates]] — institutional memory
+- Implements: [[Product Thesis - AI as Teammates]] — institutional memory
 - Implements: [[Principle - Compound Capability]] — knowledge compounds over time
 - Feeds: [[Standard - Knowledge Framework]] — historical patterns
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — teammates have memory
+- Product Thesis: [[Product Thesis - AI as Teammates]] — teammates have memory
 - Principle: [[Principle - Compound Capability]] — accumulated wisdom creates value
 - Driver: Builders need institutional memory. Conan ensures nothing is lost and patterns surface.
 

--- a/docs/context-library/product/agents/Agent - George.md
+++ b/docs/context-library/product/agents/Agent - George.md
@@ -11,12 +11,12 @@ The Factory Foreman who manages the software factory floor — the production sy
 - Manages: Factory metrics (WIP Balance, Blocked Count, Decision Velocity, Cycle Time, First-Pass Yield, ECO Rate)
 - Manages: Shift plans and resource allocation recommendations
 - Coordinates with: [[Agent - Conan]] — routes PATCH station work to Conan for context library updates; [[Agent - Sam]] — routes MAKE station work to Sam for implementation; Human operators — routes DECIDE station work to the right person
-- Implements: [[Strategy - AI as Teammates]] — operational intelligence
+- Implements: [[Product Thesis - AI as Teammates]] — operational intelligence
 - Feeds: Factory dashboard snapshots for historical trend analysis
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — teammates manage operations, not just tasks
+- Product Thesis: [[Product Thesis - AI as Teammates]] — teammates manage operations, not just tasks
 - Driver: A software factory without a foreman is just a backlog. George ensures work flows through stations in the right order, resources go where they're needed, and bottlenecks get found before the whole line stops.
 
 ## WHEN: Timeline

--- a/docs/context-library/product/agents/Agent - Jarvis.md
+++ b/docs/context-library/product/agents/Agent - Jarvis.md
@@ -12,7 +12,7 @@ The builder's Counselor — a steward whose counsel you seek before making decis
 - Manages: [[Artifact - The Agenda]] — drives session structure
 - Manages: [[Standard - Knowledge Framework]] — synthesizes patterns across agents
 - Coordinates with: [[Agent - Conan]] — receives historical patterns for strategic context; [[Agent - Marvin]] — provides strategic context for project creation and prioritization; [[Agent - Mesa]] — receives routed strategic questions from the Life Map
-- Implements: [[Strategy - AI as Teammates]] — primary relationship agent
+- Implements: [[Product Thesis - AI as Teammates]] — primary relationship agent
 - Implements: [[Principle - Earn Don't Interrogate]] — elicitation over interrogation
 - Implements: [[Principle - First 72 Hours]] -- opens the onboarding portal
 - Implements: [[Principle - Action Before Explanation]] -- asks, doesn't explain
@@ -20,7 +20,7 @@ The builder's Counselor — a steward whose counsel you seek before making decis
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — Jarvis embodies the teammate relationship
+- Product Thesis: [[Product Thesis - AI as Teammates]] — Jarvis embodies the teammate relationship
 - Principle: [[Principle - Plans Are Hypotheses]] — tone never implies failure for adaptation
 - Driver: Builders need a strategic counsel who knows them deeply. Jarvis is the primary relationship — the agent who understands the whole picture.
 

--- a/docs/context-library/product/agents/Agent - Marvin.md
+++ b/docs/context-library/product/agents/Agent - Marvin.md
@@ -18,8 +18,8 @@ During onboarding, Marvin's entrance IS a wow beat — he appears on the map alr
 - Manages: Attendants — AI agents for task execution
 - Manages: Human delegation relationships — family, colleagues, contractors
 - Coordinates with: [[Agent - Jarvis]] — receives strategic direction and Charter context for project framing; [[Agent - Conan]] — requests precedent data from similar past projects and historical performance data for priority scoring
-- Implements: [[Strategy - Superior Process]] — structured project development and prioritization
-- Implements: [[Strategy - AI as Teammates]] — team coordination and delegation
+- Implements: [[Product Thesis - Superior Process]] — structured project development and prioritization
+- Implements: [[Product Thesis - AI as Teammates]] — team coordination and delegation
 - Implements: [[Principle - Earn Don't Interrogate]] — progressive capture, not upfront interrogation
 - Implements: [[Principle - Action Before Explanation]] — arrives with work done, not questions
 - Implements: [[Principle - The WOW Chain]] — Marvin's entrance is wow beat #3 (relational surprise)
@@ -30,7 +30,7 @@ During onboarding, Marvin's entrance IS a wow beat — he appears on the map alr
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — Marvin embodies structured process across the full operational cycle
+- Product Thesis: [[Product Thesis - Superior Process]] — Marvin embodies structured process across the full operational cycle
 - Principle: [[Principle - Earn Don't Interrogate]] — captures progressively, never blocks
 - Driver: Builders need an operational partner who can take strategic intent and turn it into organized, prioritized, delegated action. Marvin is that partner — from first idea through weekly commitment to team assignment.
 

--- a/docs/context-library/product/agents/Agent - Mesa.md
+++ b/docs/context-library/product/agents/Agent - Mesa.md
@@ -12,13 +12,13 @@ The Life Map Advisor — a friendly, helpful presence available on-call througho
 - Manages: [[Capability - Zoom Navigation]] — assists with zoom-level transitions
 - Manages: [[Component - Hex Tile]] — explains tile indicators and visual states
 - Coordinates with: [[Agent - Jarvis]] — routes strategic questions to the Council Chamber; [[Agent - Marvin]] — routes operational questions (priority, project creation, delegation) to the appropriate room
-- Implements: [[Strategy - Spatial Visibility]] — helps builders work with spatial interface
+- Implements: [[Product Thesis - Spatial Visibility]] — helps builders work with spatial interface
 - Implements: [[Principle - Guide When Helpful]] — available when needed, not intrusive
 - Implements: [[Principle - First 72 Hours]] — first-contact behavior during onboarding
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — spatial interface needs in-context help
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — spatial interface needs in-context help
 - Principle: [[Principle - Guide When Helpful]] — present when needed, invisible when not
 - Driver: Builders working on the Life Map need help without leaving context. Mesa is the local guide.
 

--- a/docs/context-library/product/artifacts/Artifact - The Agenda.md
+++ b/docs/context-library/product/artifacts/Artifact - The Agenda.md
@@ -19,7 +19,7 @@ The session structure that guides conversations in the Council Chamber — a cus
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — good conversations have shape
+- Product Thesis: [[Product Thesis - Superior Process]] — good conversations have shape
 - Principle: [[Principle - Guide When Helpful]] — structure aids, doesn't control
 - Driver: Strategic conversations can wander aimlessly. The Agenda provides just enough structure to keep them productive.
 - Constraints: The Agenda provides shape, not control. Enough structure to be productive, enough flexibility to be human. Builders can override, modify, or skip any agenda item.

--- a/docs/context-library/product/artifacts/Artifact - The Charter.md
+++ b/docs/context-library/product/artifacts/Artifact - The Charter.md
@@ -24,7 +24,7 @@ The living strategic document maintained in the Council Chamber — a builder's 
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — teammates need shared context
+- Product Thesis: [[Product Thesis - AI as Teammates]] — teammates need shared context
 - Principle: [[Principle - Plans Are Hypotheses]] — strategic documents adapt
 - Driver: Jarvis needs to know what matters to the builder. The Charter captures that — not as rigid doctrine but as living understanding.
 - Constraints: The Charter belongs to the builder, not the system. Jarvis proposes updates, the builder decides. The Charter describes current understanding, never binding commitments.

--- a/docs/context-library/product/capabilities/Capability - Felt Experience.md
+++ b/docs/context-library/product/capabilities/Capability - Felt Experience.md
@@ -18,7 +18,7 @@ The builder rates how draining their work feels on a 1-10 scale with color gradi
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — capacity awareness requires data
+- Product Thesis: [[Product Thesis - Superior Process]] — capacity awareness requires data
 - Principle: [[Principle - Earn Don't Interrogate]] — one simple question captures rich capacity data
 - Driver: Builders don't know their capacity in abstract numbers. But they know how work feels. The felt experience slider translates subjective experience into data the stewards can reason about — without forcing the builder to learn a framework or fill out a form.
 

--- a/docs/context-library/product/capabilities/Capability - Purpose Assignment.md
+++ b/docs/context-library/product/capabilities/Capability - Purpose Assignment.md
@@ -19,7 +19,7 @@ The moment during project creation (Stage 2) when a builder declares what the ti
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — stream assignment enables structural protection
+- Product Thesis: [[Product Thesis - Superior Process]] — stream assignment enables structural protection
 - Principle: [[Principle - Familiarity Over Function]] — the same task is Gold for one person and Bronze for another
 - Decision: Subjective classification over objective criteria. The builder's relationship to the work is the only classification that matters.
 

--- a/docs/context-library/product/capabilities/Capability - System Actions.md
+++ b/docs/context-library/product/capabilities/Capability - System Actions.md
@@ -19,7 +19,7 @@ The three operations available for planted systems: Hibernate (pause temporarily
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — infrastructure needs lifecycle management
+- Product Thesis: [[Product Thesis - Superior Process]] — infrastructure needs lifecycle management
 - Principle: [[Principle - Plans Are Hypotheses]] — systems can be adjusted as life changes
 - Driver: Systems are long-lived but not permanent. Builders need ways to pause, improve, or end them.
 

--- a/docs/context-library/product/capabilities/Capability - Week-in-Review.md
+++ b/docs/context-library/product/capabilities/Capability - Week-in-Review.md
@@ -20,7 +20,7 @@ The structured end-of-week reflection where builders review what happened agains
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — reflection requires partnership
+- Product Thesis: [[Product Thesis - AI as Teammates]] — reflection requires partnership
 - Principle: [[Principle - Plans Are Hypotheses]] — review tests hypotheses
 - Principle: [[Principle - Compound Capability]] — learnings compound
 - Driver: Builders need to process what happened, not just move to next week. Week-in-Review creates that processing.

--- a/docs/context-library/product/capabilities/Capability - Weekly Planning.md
+++ b/docs/context-library/product/capabilities/Capability - Weekly Planning.md
@@ -20,7 +20,7 @@ The structured beginning-of-week ritual where builders select their Work at Hand
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — weekly commitment deserves attention
+- Product Thesis: [[Product Thesis - Superior Process]] — weekly commitment deserves attention
 - Principle: [[Principle - Protect Transformation]] — selection enforces stream constraints
 - Principle: [[Principle - Empty Slots Strategic]] — intentional emptiness is valid choice
 - Driver: Builders need a moment to decide what matters this week. Weekly Planning creates that moment.

--- a/docs/context-library/product/capabilities/Capability - Workspace Navigation.md
+++ b/docs/context-library/product/capabilities/Capability - Workspace Navigation.md
@@ -19,7 +19,7 @@ The interface for moving between LifeBuild's three main workspaces — Life Map 
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — workspaces are distinct places
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — workspaces are distinct places
 - Principle: [[Principle - Familiarity Over Function]] — movement should feel intuitive
 - Driver: Builders need to move between execution, planning, and learning fluidly. Navigation makes that movement effortless.
 - Constraints: Navigation connects workspaces without disrupting flow. Transitions preserve all state (zoom, scroll, selection). Three workspaces are peers, not a hierarchy.

--- a/docs/context-library/product/capabilities/Capability - Zoom Navigation.md
+++ b/docs/context-library/product/capabilities/Capability - Zoom Navigation.md
@@ -18,7 +18,7 @@ The scale control system for the Life Map, allowing builders to smoothly transit
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — builders need both overview and detail
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — builders need both overview and detail
 - Principle: [[Principle - Visibility Creates Agency]] — agency requires ability to change perspective
 - Driver: Life is complex — builders need to zoom out for big picture, zoom in for action. Same space, different scales.
 - Constraints: Zoom controls information density, not access. All data exists at every level — zoom reveals or conceals detail layers. The Table remains fixed size regardless of zoom.

--- a/docs/context-library/product/components/Component - Bronze Position.md
+++ b/docs/context-library/product/components/Component - Bronze Position.md
@@ -20,7 +20,7 @@ The rightmost position on The Table, displaying a stack of operational tasks —
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — operational work managed separately
+- Product Thesis: [[Product Thesis - Superior Process]] — operational work managed separately
 - Principle: [[Principle - Protect Transformation]] — Bronze has dedicated space, cannot overflow into Gold/Silver
 - Decision: Stack (multiple tasks) rather than single project because Bronze represents operational multiplicity. Maintenance is many small things, not one big thing.
 

--- a/docs/context-library/product/components/Component - Campfire.md
+++ b/docs/context-library/product/components/Component - Campfire.md
@@ -22,8 +22,8 @@ A temporary compression phase -- the intimate space where the builder first enco
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] -- Jarvis is the first face
-- Strategy: [[Strategy - Spatial Visibility]] -- the compression makes the spatial release land
+- Product Thesis: [[Product Thesis - AI as Teammates]] -- Jarvis is the first face
+- Product Thesis: [[Product Thesis - Spatial Visibility]] -- the compression makes the spatial release land
 - Principle: [[Principle - Compression and Release]] -- the Campfire exists TO create compression. Without it, the map reveal is just a screen loading.
 - Driver: The builder needs an intimate, focused moment before the world opens. The compression loads the spring. The single question creates the builder's first action. The release rewards it.
 

--- a/docs/context-library/product/components/Component - Gold Position.md
+++ b/docs/context-library/product/components/Component - Gold Position.md
@@ -19,7 +19,7 @@ The leftmost position on The Table, displaying a single expansion project — wo
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — structural protection for transformation
+- Product Thesis: [[Product Thesis - Superior Process]] — structural protection for transformation
 - Principle: [[Principle - Protect Transformation]] — Gold slot cannot be invaded by Bronze
 - Decision: One Gold maximum because two transformations compete for attention and neither advances. The limit forces commitment.
 

--- a/docs/context-library/product/components/Component - Hex Tile.md
+++ b/docs/context-library/product/components/Component - Hex Tile.md
@@ -20,7 +20,7 @@ An individual hexagonal tile on the grid representing a single project or system
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — tiles are the atomic spatial unit
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — tiles are the atomic spatial unit
 - Principle: [[Principle - Visual Recognition]] — consistent tile format aids scanning
 - Driver: Builders need to recognize work at a glance. Tiles provide consistent, scannable representation.
 

--- a/docs/context-library/product/components/Component - Silver Position.md
+++ b/docs/context-library/product/components/Component - Silver Position.md
@@ -18,7 +18,7 @@ The center position on The Table, displaying a single capacity-building project 
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — dedicated slot for leverage work
+- Product Thesis: [[Product Thesis - Superior Process]] — dedicated slot for leverage work
 - Principle: [[Principle - Compound Capability]] — Silver builds infrastructure that makes future weeks easier
 - Decision: One Silver maximum for same focus reasons as Gold. Capacity-building benefits from sustained attention.
 

--- a/docs/context-library/product/overlays/Overlay - The Table.md
+++ b/docs/context-library/product/overlays/Overlay - The Table.md
@@ -31,8 +31,8 @@ A persistent priority spotlight that sits at the top of the Life Map, displaying
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — priority visible at all times
-- Strategy: [[Strategy - Superior Process]] — structured weekly commitment
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — priority visible at all times
+- Product Thesis: [[Product Thesis - Superior Process]] — structured weekly commitment
 - Principle: [[Principle - Protect Transformation]] — Gold/Silver slots protected from Bronze overflow
 - Principle: [[Principle - Empty Slots Strategic]] — empty positions are valid choices
 - Driver: Builders need constant awareness of what they've committed to this week. The Table is the answer to "what am I working on right now?"

--- a/docs/context-library/product/primitives/Primitive - Project.md
+++ b/docs/context-library/product/primitives/Primitive - Project.md
@@ -19,8 +19,8 @@ A discrete initiative with a finish line — bounded work that completes and mov
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — structured work management
-- Strategy: [[Strategy - Spatial Visibility]] — projects have spatial presence on hex grid
+- Product Thesis: [[Product Thesis - Superior Process]] — structured work management
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — projects have spatial presence on hex grid
 - Principle: [[Principle - Plans Are Hypotheses]] — project plans can adapt
 - Driver: Builders need bounded containers for work with finish lines. The question for projects is always: "How close am I to finished?"
 

--- a/docs/context-library/product/primitives/Primitive - System.md
+++ b/docs/context-library/product/primitives/Primitive - System.md
@@ -17,7 +17,7 @@ Planted infrastructure that generates work indefinitely. Unlike projects, system
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — infrastructure reduces future cognitive load
+- Product Thesis: [[Product Thesis - Superior Process]] — infrastructure reduces future cognitive load
 - Principle: [[Principle - Compound Capability]] — planted systems make future weeks easier
 - Driver: Builders need containers for recurring work that runs itself. The question for systems is: "Is it running smoothly?"
 

--- a/docs/context-library/product/primitives/Primitive - Task.md
+++ b/docs/context-library/product/primitives/Primitive - Task.md
@@ -15,7 +15,7 @@ A single, completable action that contributes to a project's objectives or fulfi
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — work decomposed into actionable units
+- Product Thesis: [[Product Thesis - Superior Process]] — work decomposed into actionable units
 - Principle: [[Principle - Visibility Creates Agency]] — tasks make progress visible
 - Driver: Builders need atomic work units they can complete in a session (typically 15min-2hrs).
 

--- a/docs/context-library/product/rooms/Room - Council Chamber.md
+++ b/docs/context-library/product/rooms/Room - Council Chamber.md
@@ -17,12 +17,12 @@ Jarvis's dedicated space in the Strategy Studio — where builders engage in hig
   - [[Room - Roster Room]] — delegation management
 - Conforms to:
   - [[Standard - Planning Calibration]] — strategic conversations frame plans as hypotheses
-- Implements: [[Strategy - AI as Teammates]] — deepest advisor relationship
+- Implements: [[Product Thesis - AI as Teammates]] — deepest advisor relationship
 - Implements: [[Principle - Earn Don't Interrogate]] — Jarvis elicits, never interrogates
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — Jarvis is the primary AI relationship
+- Product Thesis: [[Product Thesis - AI as Teammates]] — Jarvis is the primary AI relationship
 - Principle: [[Principle - Plans Are Hypotheses]] — strategic conversations hold plans lightly
 - Driver: Builders need a thinking partner who knows their whole picture. The Council Chamber hosts that partnership.
 - Constraints: Council Chamber is the builder's space, not Jarvis's office. The builder controls pace, topic, and depth of conversation. Jarvis guides, never drives.

--- a/docs/context-library/product/rooms/Room - Drafting Room.md
+++ b/docs/context-library/product/rooms/Room - Drafting Room.md
@@ -15,14 +15,14 @@ Marvin's dedicated space — where builders create new projects and systems, gui
 - Conforms to:
   - [[Standard - Visual Language]] — creation stage visual treatments
 - Implements: [[System - Four-Stage Creation]] — guided process
-- Implements: [[Strategy - Superior Process]] — structured project development
+- Implements: [[Product Thesis - Superior Process]] — structured project development
 - Implements: [[Principle - Earn Don't Interrogate]] — progressive capture
 - Creates: [[Primitive - Project]] — output of project creation flow
 - Creates: [[Primitive - System]] — output of system creation flow
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — creation deserves structure
+- Product Thesis: [[Product Thesis - Superior Process]] — creation deserves structure
 - Principle: [[Principle - Earn Don't Interrogate]] — Marvin guides without blocking
 - Driver: Builders need help turning ideas into actionable projects. The Drafting Room provides that translation.
 - Constraints: Drafting Room translates ideas into projects or systems without judging them. Marvin guides structure, not evaluates worth. Quick capture is always available.

--- a/docs/context-library/product/rooms/Room - Project Board.md
+++ b/docs/context-library/product/rooms/Room - Project Board.md
@@ -22,11 +22,11 @@ The detail overlay that opens when a builder clicks any project tile — a focus
   - [[Standard - Project States]] — shows current state, enables transitions
   - [[Standard - Image Evolution]] — shows current illustration stage
   - [[Standard - Visual Language]] — project state indicators, category colors
-- Implements: [[Strategy - Superior Process]] — detailed work needs detailed view
+- Implements: [[Product Thesis - Superior Process]] — detailed work needs detailed view
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — detailed work needs detailed view
+- Product Thesis: [[Product Thesis - Superior Process]] — detailed work needs detailed view
 - Principle: [[Principle - Familiarity Over Function]] — board metaphor feels natural for project management
 - Driver: Builders need to work on projects, not just see them. The Project Board is the workspace within the workspace.
 - Constraints: Project Board is for working within a single project. Cross-project decisions happen on [[Overlay - The Table]] and in the [[Room - Sorting Room]], not here. Overlay behavior preserves spatial context.

--- a/docs/context-library/product/rooms/Room - Roster Room.md
+++ b/docs/context-library/product/rooms/Room - Roster Room.md
@@ -12,14 +12,14 @@ Marvin's delegation space — where builders assign Attendants to delegatable ta
   - [[Room - Council Chamber]] — strategic conversation
   - [[Room - Sorting Room]] — priority selection
   - [[Room - Drafting Room]] — project creation
-- Implements: [[Strategy - AI as Teammates]] — team coordination
+- Implements: [[Product Thesis - AI as Teammates]] — team coordination
 - Implements: [[Principle - Compound Capability]] — delegation patterns improve
 - Assigns: Attendants — AI agents for task execution
 - Configures: Human delegation — family, colleagues, contractors
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — builders have a team
+- Product Thesis: [[Product Thesis - AI as Teammates]] — builders have a team
 - Principle: [[Principle - Compound Capability]] — team effectiveness compounds over time
 - Driver: Builders shouldn't do everything alone. The Roster Room is where delegation happens.
 - Constraints: Delegation is always builder-initiated or builder-approved. Marvin recommends, the builder assigns. No autonomous task handoff. Human delegation tracking is reminder-based, not enforcement-based.

--- a/docs/context-library/product/rooms/Room - Sorting Room.md
+++ b/docs/context-library/product/rooms/Room - Sorting Room.md
@@ -19,13 +19,13 @@ Marvin's prioritization space in the Strategy Studio — where builders make pri
 - Conforms to:
   - [[Standard - Visual Language]] — ranking interface uses stream colors and state treatments
   - [[Standard - Planning Calibration]] — priority rankings as testable predictions
-- Implements: [[Strategy - Superior Process]] — structured prioritization
+- Implements: [[Product Thesis - Superior Process]] — structured prioritization
 - Uses: [[System - Priority Queue Architecture]] — source of candidates
 - Uses: [[Standard - Priority Score]] — ranking logic
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — prioritization deserves its own space
+- Product Thesis: [[Product Thesis - Superior Process]] — prioritization deserves its own space
 - Principle: [[Principle - Familiarity Over Function]] — sorting metaphor is intuitive
 - Principle: [[Principle - Protect Transformation]] — selection process enforces stream constraints
 - Driver: Builders need help seeing options and making choices. The Sorting Room presents candidates and guides selection.

--- a/docs/context-library/product/rooms/Room - System Board.md
+++ b/docs/context-library/product/rooms/Room - System Board.md
@@ -18,7 +18,7 @@ The detail overlay that opens when a builder clicks any system tile — a focuse
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — systems need monitoring interface
+- Product Thesis: [[Product Thesis - Superior Process]] — systems need monitoring interface
 - Principle: [[Principle - Visibility Creates Agency]] — system health visible, not hidden
 - Driver: Builders need to see how their infrastructure is performing. The System Board answers "is this system healthy?"
 - Constraints: System Board monitors infrastructure health, not builder productivity. System health reflects cycle adherence and task generation, not how much the builder accomplished. Yellow is attention, Red is concern — neither is judgment.

--- a/docs/context-library/product/standards/Standard - Four Verbs.md
+++ b/docs/context-library/product/standards/Standard - Four Verbs.md
@@ -12,11 +12,11 @@ Every action a builder takes maps to one of four verbs: **Tend**, **Invest**, **
   - [[System - Capacity Economy]] — Maintain/Invest/Spend classifies capacity flow direction (steward-side reasoning)
   - [[Loop - Daily Check-In]] — each micro loop is one of the four verbs
   - [[Loop - Expedition Cycle]] — expeditions are composed of verb-classified activities
-- Implements: [[Strategy - Superior Process]] — legible action classification
+- Implements: [[Product Thesis - Superior Process]] — legible action classification
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — builders need a simple vocabulary for what they're doing
+- Product Thesis: [[Product Thesis - Superior Process]] — builders need a simple vocabulary for what they're doing
 - Driver: Without a verb framework, all work feels the same — undifferentiated tasks on a list. The Four Verbs give builders a way to understand what kind of energy they're spending. Tending feels different from Venturing. Restoring feels different from Investing. Naming the difference creates awareness.
 
 ## WHEN: Timeline

--- a/docs/context-library/product/standards/Standard - Naming Architecture.md
+++ b/docs/context-library/product/standards/Standard - Naming Architecture.md
@@ -12,12 +12,12 @@ The naming hierarchy for all characters in LifeBuild: **Builder** (the person), 
   - [[Agent - Marvin]] — Steward (Manager)
   - [[Agent - Conan]] — Steward (Librarian)
   - [[Room - Roster Room]] — where Attendants are assigned
-  - [[Strategy - AI as Teammates]] — the naming embodies the teammate model
-- Implements: [[Strategy - AI as Teammates]] — teammates have names, roles, and relationships
+  - [[Product Thesis - AI as Teammates]] — the naming embodies the teammate model
+- Implements: [[Product Thesis - AI as Teammates]] — teammates have names, roles, and relationships
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — naming is how the teammate relationship becomes legible
+- Product Thesis: [[Product Thesis - AI as Teammates]] — naming is how the teammate relationship becomes legible
 - Driver: The names communicate the social contract. "Builder" says: you are the one who decides what to build. "Stewards" says: we serve and advise, but we do not direct. "Attendants" says: we handle the work you shouldn't be doing yourself. The hierarchy is intentional — it encodes authority, humility, and purpose.
 
 ## WHEN: Timeline

--- a/docs/context-library/product/standards/Standard - Reward Philosophy.md
+++ b/docs/context-library/product/standards/Standard - Reward Philosophy.md
@@ -13,12 +13,12 @@ LifeBuild uses no extrinsic reward mechanics. The moral principle: building capa
   - [[Journey - Sanctuary Progression]] — progression IS the reward
   - [[Component - Hex Tile]] — visual evolution as environmental reward
   - [[System - Overgrowth]] — absence is never punished
-- Implements: [[Strategy - Superior Process]] — intrinsic motivation over extrinsic
+- Implements: [[Product Thesis - Superior Process]] — intrinsic motivation over extrinsic
 - Implements: [[Principle - Protect Transformation]] — Gold ventures shift to aspiration as the natural reward
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — extrinsic rewards undermine the deep process LifeBuild teaches
+- Product Thesis: [[Product Thesis - Superior Process]] — extrinsic rewards undermine the deep process LifeBuild teaches
 - Driver: The productivity industry is addicted to extrinsic motivation — streaks, points, badges, leaderboards. These work short-term but crowd out intrinsic motivation long-term. LifeBuild makes the opposite bet: the sanctuary itself IS the reward. A more beautiful map, more capable stewards, more free capacity — these are real, not gamified.
 
 ## WHEN: Timeline

--- a/docs/context-library/product/structures/Structure - Hex Grid.md
+++ b/docs/context-library/product/structures/Structure - Hex Grid.md
@@ -17,14 +17,14 @@ The spatial organization canvas that fills most of the Life Map — a tessellate
   - [[Standard - Visual Language]] — colors, states, indicators
   - [[Standard - Spatial Interaction Rules]] — builder-driven placement, no auto-organization
 - Implements:
-  - [[Strategy - Spatial Visibility]] — work has spatial position
+  - [[Product Thesis - Spatial Visibility]] — work has spatial position
   - [[Principle - Bidirectional Loop]] — arrangement reflects and shapes understanding
   - [[Principle - Visual Recognition]] — spatial memory for navigation
 - Uses: [[Capability - Zoom Navigation]] — scale changes what's visible
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — hexagons are the spatial unit
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — hexagons are the spatial unit
 - Principle: [[Principle - Visual Recognition]] — "my health stuff is upper-left" becomes automatic
 - Principle: [[Principle - Familiarity Over Function]] — spatial metaphor feels natural
 - Decision: Hexagons (not squares) because they tessellate without privileged axes. Every hex has six equal neighbors — no "up is better than sideways" bias.

--- a/docs/context-library/product/structures/Structure - Kanban Board.md
+++ b/docs/context-library/product/structures/Structure - Kanban Board.md
@@ -14,13 +14,13 @@ The task flow interface within a Project Board — a visual representation of ta
 - Conforms to:
   - [[Standard - Visual Language]] — task cards, column states render per spec
 - Implements:
-  - [[Strategy - Spatial Visibility]] — progress has spatial form
+  - [[Product Thesis - Spatial Visibility]] — progress has spatial form
   - [[Principle - Visual Recognition]] — task state instantly visible
 - Related: [[System - Bronze Stack]] — Bronze tasks may show here
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — work flow should be visible
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — work flow should be visible
 - Principle: [[Principle - Visual Recognition]] — familiar pattern for task management
 - Principle: [[Principle - Familiarity Over Function]] — Kanban is widely understood
 - Driver: Builders need to see and manage task flow within projects. Kanban provides that at-a-glance view.

--- a/docs/context-library/product/systems/System - Adaptation.md
+++ b/docs/context-library/product/systems/System - Adaptation.md
@@ -32,12 +32,12 @@ The invisible mechanism governing how weekly commitments change after planning. 
   - [[Agent - Marvin]] — supports transitions, no judgment
 - Rationale:
   - [[Principle - Plans Are Hypotheses]] — adaptation is expected
-  - [[Strategy - Superior Process]] — structured flexibility
+  - [[Product Thesis - Superior Process]] — structured flexibility
 
 ## WHY: Rationale
 
 - Principle: [[Principle - Plans Are Hypotheses]] — plans change; that's leadership, not failure
-- Strategy: [[Strategy - Superior Process]] — adaptation has structure, not chaos
+- Product Thesis: [[Product Thesis - Superior Process]] — adaptation has structure, not chaos
 - Driver: Life doesn't wait for Friday planning. Builders need to respond to change without guilt or friction.
 - Constraints: Adaptation carries no guilt tax. The system never frames mid-week changes as failure. Modification UI feels like adjusting strategy, not editing a failure report.
 

--- a/docs/context-library/product/systems/System - Bronze Operations.md
+++ b/docs/context-library/product/systems/System - Bronze Operations.md
@@ -15,7 +15,7 @@ The builder-facing workflow for Bronze stream interaction — mode selection, ta
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — structured Bronze mechanics prevent ad-hoc maintenance chaos
+- Product Thesis: [[Product Thesis - Superior Process]] — structured Bronze mechanics prevent ad-hoc maintenance chaos
 - System: [[Standard - Three-Stream Portfolio]] — Bronze requires unique mechanics
 - Principle: [[Principle - Protect Transformation]] — Bronze stays contained
 - Driver: Operational work behaves differently than transformational work. Bronze Operations codifies that difference.

--- a/docs/context-library/product/systems/System - Bronze Stack.md
+++ b/docs/context-library/product/systems/System - Bronze Stack.md
@@ -36,12 +36,12 @@ The data mechanism governing which operational tasks populate the Bronze positio
   - [[Overlay - The Table]] — Bronze position displays the stack
   - [[Component - Bronze Position]] — rightmost position on The Table
 - Rationale:
-  - [[Strategy - Superior Process]] — operational work managed separately from transformation
+  - [[Product Thesis - Superior Process]] — operational work managed separately from transformation
   - [[Principle - Protect Transformation]] — Bronze has its own space, can't invade Gold/Silver
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — operational work managed separately from transformation
+- Product Thesis: [[Product Thesis - Superior Process]] — operational work managed separately from transformation
 - Principle: [[Principle - Protect Transformation]] — Bronze has its own space, can't invade Gold/Silver
 - Driver: Bronze represents multiplicity (many tasks) while Gold/Silver represent singularity (one project each).
 

--- a/docs/context-library/product/systems/System - Capacity Economy.md
+++ b/docs/context-library/product/systems/System - Capacity Economy.md
@@ -18,11 +18,11 @@ The single currency in LifeBuild is capacity — a composite of time, energy, co
 - Agents:
   - [[Agent - Jarvis]] — reasons about capacity patterns, surfaces honest picture
   - [[Agent - Marvin]] — models capacity in expedition shaping
-- Implements: [[Strategy - Superior Process]] — structured capacity management
+- Implements: [[Product Thesis - Superior Process]] — structured capacity management
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — capacity is the constraint that makes process necessary
+- Product Thesis: [[Product Thesis - Superior Process]] — capacity is the constraint that makes process necessary
 - Principle: [[Principle - Empty Slots Strategic]] — capacity-first philosophy
 - Driver: Builders are overwhelmed not because they lack knowledge but because they lack bandwidth. The Capacity Economy models this constraint honestly and creates the dynamics (compounding, The Shift) that resolve it over time.
 

--- a/docs/context-library/product/systems/System - Clustering.md
+++ b/docs/context-library/product/systems/System - Clustering.md
@@ -35,13 +35,13 @@ The emergent spatial behavior where builders place related hex tiles adjacent to
   - [[Component - Campfire]] — first clusters form around origin
 - Rationale:
   - [[Principle - Bidirectional Loop]] — arrangement reflects and shapes understanding
-  - [[Strategy - Spatial Visibility]] — spatial proximity carries meaning
+  - [[Product Thesis - Spatial Visibility]] — spatial proximity carries meaning
   - [[Principle - Visual Recognition]] — "my health stuff is upper-left"
   - [[Principle - Familiarity Over Function]] — builders organize intuitively
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — space carries meaning
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — space carries meaning
 - Principle: [[Principle - Visual Recognition]] — spatial memory aids navigation
 - Principle: [[Principle - Familiarity Over Function]] — builders organize intuitively
 - Driver: Builders naturally group related things together. Clustering makes this explicit and learnable.

--- a/docs/context-library/product/systems/System - Four-Stage Creation.md
+++ b/docs/context-library/product/systems/System - Four-Stage Creation.md
@@ -15,7 +15,7 @@ The progressive development process for projects (and the template for system cr
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — structured process for project development
+- Product Thesis: [[Product Thesis - Superior Process]] — structured process for project development
 - Driver: Cognitive mode separation prevents overload. Brainstorming and critiquing at the same time degrades both.
 - Decision: Four stages, not three or five, because the four cognitive modes (divergent capture, convergent definition, generative planning, evaluative comparison) are distinct enough to warrant separation.
 

--- a/docs/context-library/product/systems/System - Onboarding.md
+++ b/docs/context-library/product/systems/System - Onboarding.md
@@ -18,7 +18,7 @@ The mechanism that implements the portal-first onboarding -- guiding new builder
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] -- agents are introduced through action, not explanation
+- Product Thesis: [[Product Thesis - AI as Teammates]] -- agents are introduced through action, not explanation
 - Principle: [[Principle - First 72 Hours]] -- first impressions define the relationship
 - Principle: [[Principle - Action Before Explanation]] -- the builder acts before they understand
 - Principle: [[Principle - Compression and Release]] -- the portal creates the emotional foundation

--- a/docs/context-library/product/systems/System - Overgrowth.md
+++ b/docs/context-library/product/systems/System - Overgrowth.md
@@ -23,7 +23,7 @@ The visual and mechanical system for representing neglect on the hex grid. When 
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — overgrowth makes neglect visible on the map
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — overgrowth makes neglect visible on the map
 - Principle: [[Principle - Visibility Creates Agency]] — seeing overgrowth creates agency to tend it
 - Driver: Systems need maintenance. When maintenance lapses, the builder needs to see it — but gently, proportionally, and without guilt. Overgrowth is the sanctuary's way of saying "this garden corner needs watering" without saying "you failed."
 

--- a/docs/context-library/product/systems/System - Pipeline Architecture.md
+++ b/docs/context-library/product/systems/System - Pipeline Architecture.md
@@ -14,7 +14,7 @@ The two-queue system that separates work in development (Planning Queue) from wo
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — structured flow from capture to activation
+- Product Thesis: [[Product Thesis - Superior Process]] — structured flow from capture to activation
 - Principle: [[Principle - Earn Don't Interrogate]] — progressive investment, not upfront interrogation
 - Decision: Separating queues prevents the common failure mode where effort required to "properly create" a project discourages capturing ideas at all.
 

--- a/docs/context-library/product/systems/System - Planning Queue.md
+++ b/docs/context-library/product/systems/System - Planning Queue.md
@@ -14,7 +14,7 @@ The holding area for projects still in development — work in stages 1-3 of the
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — development is distinct from prioritization
+- Product Thesis: [[Product Thesis - Superior Process]] — development is distinct from prioritization
 - Principle: [[Principle - Earn Don't Interrogate]] — projects can be incomplete
 - Driver: Not all projects are ready for prioritization. The Planning Queue holds work-in-progress until it's ready.
 

--- a/docs/context-library/product/systems/System - Priority Queue Architecture.md
+++ b/docs/context-library/product/systems/System - Priority Queue Architecture.md
@@ -16,7 +16,7 @@ The ordered repository of all fully-planned work ready for activation, organized
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — structured prioritization replaces reactive decision-making
+- Product Thesis: [[Product Thesis - Superior Process]] — structured prioritization replaces reactive decision-making
 - Principle: [[Principle - Protect Transformation]] — stream organization prevents Bronze from crowding Gold/Silver
 - Decision: Separating Planning Queue from Priority Queue creates psychological safety — capture ideas quickly without immediately prioritizing.
 

--- a/docs/context-library/product/systems/System - Processing Layer.md
+++ b/docs/context-library/product/systems/System - Processing Layer.md
@@ -14,7 +14,7 @@ The deterministic computation engine that transforms raw builder data into State
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — agents need processed intelligence
+- Product Thesis: [[Product Thesis - AI as Teammates]] — agents need processed intelligence
 - Principle: [[Principle - Compound Capability]] — processing layer compounds agent effectiveness by doing math once, not per-agent
 - Driver: Separation of concerns. Deterministic logic (calibration math, pattern detection) shouldn't consume agent context windows. Agents add judgment and conversation quality.
 - Decision: State Summaries ~250 tokens. Compact enough for agent context, rich enough for personalized service.

--- a/docs/context-library/product/systems/System - Progressive Knowledge Capture.md
+++ b/docs/context-library/product/systems/System - Progressive Knowledge Capture.md
@@ -8,14 +8,14 @@ The knowledge acquisition mechanism agents use to learn about builders over time
 
 - Used by: All agents, especially [[Agent - Jarvis]], [[Agent - Mesa]]
 - Implements: [[Principle - Earn Don't Interrogate]]
-- Implements: [[Strategy - AI as Teammates]]
+- Implements: [[Product Thesis - AI as Teammates]]
 - Feeds: [[Standard - Knowledge Framework]] — where captured knowledge lives
 - Feeds: [[Artifact - The Charter]] — strategic knowledge captured here
 
 ## WHY: Rationale
 
 - Principle: [[Principle - Earn Don't Interrogate]] — Progressive Knowledge Capture is how agents honor this principle
-- Strategy: [[Strategy - AI as Teammates]] — teammates learn organically, not via forms
+- Product Thesis: [[Product Thesis - AI as Teammates]] — teammates learn organically, not via forms
 - Driver: Upfront questionnaires create friction and capture stale data. Progressive capture builds living, contextual knowledge through natural interaction.
 
 ## WHEN: Timeline

--- a/docs/context-library/product/systems/System - Service Level Progression.md
+++ b/docs/context-library/product/systems/System - Service Level Progression.md
@@ -32,7 +32,7 @@ The invisible state machine governing how AI capabilities evolve based on builde
   - Agent quality scales with level — higher levels yield better recommendations, deeper pattern recognition
 - Rationale:
   - [[Principle - Compound Capability]] — visible compounding of system intelligence
-  - [[Strategy - AI as Teammates]] — agents improve with levels
+  - [[Product Thesis - AI as Teammates]] — agents improve with levels
 
 ## WHY: Rationale
 

--- a/docs/context-library/product/systems/System - Smoke Signals.md
+++ b/docs/context-library/product/systems/System - Smoke Signals.md
@@ -14,7 +14,7 @@ The ambient notification mechanism that surfaces items needing attention through
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — ambient signals leverage spatial awareness
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — ambient signals leverage spatial awareness
 - Principle: [[Principle - Visibility Creates Agency]] — builders see problems early
 - Principle: [[Principle - Guide When Helpful]] — helpful signals, not nagging alerts
 - Driver: Builders need awareness without bombardment. Smoke Signals make problems visible without demanding immediate action.

--- a/docs/context-library/product/systems/System - Weekly Priority.md
+++ b/docs/context-library/product/systems/System - Weekly Priority.md
@@ -16,7 +16,7 @@ The mechanism that produces and maintains a builder's active weekly commitment �
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — weekly commitment creates focus
+- Product Thesis: [[Product Thesis - Superior Process]] — weekly commitment creates focus
 - Principle: [[Principle - Protect Transformation]] — stream constraints enforced
 - Principle: [[Principle - Empty Slots Strategic]] — empty positions are valid choices
 - Driver: Builders need clarity on "what am I working on this week?" Weekly Priority answers that question.

--- a/docs/context-library/product/zones/Zone - Archives.md
+++ b/docs/context-library/product/zones/Zone - Archives.md
@@ -16,13 +16,13 @@ The learning workspace — where completed projects, uprooted systems, and histo
   - Completed projects with full history
   - Uprooted systems with full history
   - Historical performance data
-- Implements: [[Strategy - AI as Teammates]] — institutional memory
+- Implements: [[Product Thesis - AI as Teammates]] — institutional memory
 - Implements: [[Principle - Compound Capability]] — accumulated wisdom
 - Feeds: [[Standard - Knowledge Framework]] — historical patterns
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — teammates remember
+- Product Thesis: [[Product Thesis - AI as Teammates]] — teammates remember
 - Principle: [[Principle - Compound Capability]] — history creates value
 - Driver: Builders need to learn from experience. The Archives preserve that experience and surface its lessons.
 - Constraints: Archives serve learning, not accountability. Historical data is the builder's memory, not a performance record. Always accessible, never gated behind agent interaction, never auto-deleted.

--- a/docs/context-library/product/zones/Zone - Life Map.md
+++ b/docs/context-library/product/zones/Zone - Life Map.md
@@ -22,7 +22,7 @@ The primary — and essentially only — workspace. The map IS the game. A spati
 - Primitives:
   - [[Primitive - Project]] — projects visible on grid
   - [[Primitive - System]] — systems visible on grid
-- Implements: [[Strategy - Spatial Visibility]] — work exists in space
+- Implements: [[Product Thesis - Spatial Visibility]] — work exists in space
 - Implements: [[Standard - Dual Presence]] — Work at Hand appears on both Table and grid
 - Implements: [[Principle - Visibility Creates Agency]] — everything visible at once
 - Conforms to: [[Standard - Visual Language]] — hex tiles, state indicators, category colors render per spec
@@ -31,7 +31,7 @@ The primary — and essentially only — workspace. The map IS the game. A spati
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — Life Map is the primary embodiment of spatial thinking
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — Life Map is the primary embodiment of spatial thinking
 - Principle: [[Principle - Visibility Creates Agency]] — builders see everything, decide what to focus on
 - Principle: [[Principle - Visual Recognition]] — spatial memory aids finding and understanding
 - Driver: Builders need a home base where all their work is visible and organized. The Life Map is that home.

--- a/docs/context-library/product/zones/Zone - Strategy Studio.md
+++ b/docs/context-library/product/zones/Zone - Strategy Studio.md
@@ -16,13 +16,13 @@ The planning workspace — a collection of specialized rooms where builders enga
 - Adjacent:
   - [[Zone - Life Map]] — execution workspace
   - [[Zone - Archives]] — learning workspace
-- Implements: [[Strategy - AI as Teammates]] — advisor conversations happen here
+- Implements: [[Product Thesis - AI as Teammates]] — advisor conversations happen here
 - Agent access: [[Agent - Jarvis]], [[Agent - Marvin]]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — planning requires conversation partners
-- Strategy: [[Strategy - Superior Process]] — planning is distinct from execution
+- Product Thesis: [[Product Thesis - AI as Teammates]] — planning requires conversation partners
+- Product Thesis: [[Product Thesis - Superior Process]] — planning is distinct from execution
 - Principle: [[Principle - Guide When Helpful]] — advisors available when builders seek them
 - Driver: Builders need space to think strategically before committing to action. The Strategy Studio provides that space.
 - Constraints: Strategy Studio is for thinking, not doing. Execution happens on Life Map. The separation between planning and execution is deliberate and structural.

--- a/docs/context-library/rationale/principles/Principle - Action Before Explanation.md
+++ b/docs/context-library/rationale/principles/Principle - Action Before Explanation.md
@@ -6,8 +6,8 @@ Comprehension follows action, never the other way around. Builders learn by doin
 
 ## WHERE: Ecosystem
 
-- Advances: [[Strategy - AI as Teammates]] -- teammates show, they don't lecture
-- Advances: [[Strategy - Spatial Visibility]] -- the map teaches by being visible, not by being explained
+- Advances: [[Product Thesis - AI as Teammates]] -- teammates show, they don't lecture
+- Advances: [[Product Thesis - Spatial Visibility]] -- the map teaches by being visible, not by being explained
 - Companion: [[Principle - Earn Don't Interrogate]] -- that principle says "never block progress with knowledge acquisition"; this principle says "never explain before acting"
 - Related: [[Principle - Compression and Release]] -- compression obscures what's coming; action-before-explanation ensures the reveal teaches through experience, not narration
 - Related: [[Principle - The WOW Chain]] -- each wow is also a lesson disguised as a surprise
@@ -20,8 +20,8 @@ Comprehension follows action, never the other way around. Builders learn by doin
 
 ## WHY: Belief
 
-- Strategy: [[Strategy - Spatial Visibility]] -- the map reveal IS the explanation; showing beats telling
-- Strategy: [[Strategy - AI as Teammates]] -- teammates demonstrate value through action, not introduction speeches
+- Product Thesis: [[Product Thesis - Spatial Visibility]] -- the map reveal IS the explanation; showing beats telling
+- Product Thesis: [[Product Thesis - AI as Teammates]] -- teammates demonstrate value through action, not introduction speeches
 - Driver: The conversation-first campfire failed because it explained the world before the builder could see it. The builder spent the conversation going "what's a hex? what do you mean stewards?" -- they never got past "what IS this?" to "what can I do here?" The fix: let them do something first, and understanding arrives as a consequence of the action, not as a prerequisite for it.
 
 ## WHEN: Timeline

--- a/docs/context-library/rationale/principles/Principle - Agreement Over Expectation.md
+++ b/docs/context-library/rationale/principles/Principle - Agreement Over Expectation.md
@@ -8,7 +8,7 @@ In first contact, this principle defers to [[Principle - Action Before Explanati
 
 ## WHERE: Ecosystem
 
-- Advances: [[Strategy - AI as Teammates]] — teammates negotiate working agreements, they don't impose defaults
+- Advances: [[Product Thesis - AI as Teammates]] — teammates negotiate working agreements, they don't impose defaults
 - Companion: [[Principle - Earn Don't Interrogate]] — that principle governs HOW we acquire knowledge (timing, tone, method); this principle governs WHAT relational knowledge matters and WHY explicit agreement beats implicit expectation
 - Governs:
   - [[Component - Campfire]] — Campfire first contact defers to [[Principle - Action Before Explanation]]; designed alliance forms through shared experience, not conversational exchange

--- a/docs/context-library/rationale/principles/Principle - Bidirectional Loop.md
+++ b/docs/context-library/rationale/principles/Principle - Bidirectional Loop.md
@@ -7,7 +7,7 @@ External representation and internal understanding strengthen each other through
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - Spatial Visibility]] — spatial organization enables the loop
+- Advances: [[Product Thesis - Spatial Visibility]] — spatial organization enables the loop
 - Governs: [[Structure - Hex Grid]], [[System - Clustering]], [[Zone - Life Map]]
 - Implemented by: [[Standard - Spatial Interaction Rules]] — makes builder spatial agency testable
 - Related: [[Principle - Visibility Creates Agency]] — seeing enables understanding

--- a/docs/context-library/rationale/principles/Principle - Compound Capability.md
+++ b/docs/context-library/rationale/principles/Principle - Compound Capability.md
@@ -7,7 +7,7 @@ When facing tradeoffs, optimize for month-12 capability, not week-1 convenience 
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - Spatial Visibility]], [[Strategy - Superior Process]], [[Strategy - AI as Teammates]]
+- Advances: [[Product Thesis - Spatial Visibility]], [[Product Thesis - Superior Process]], [[Product Thesis - AI as Teammates]]
 - Governs: [[Primitive - System]], [[Artifact - The Charter]], [[Standard - Service Levels]], [[Standard - Knowledge Framework]]
 - Systems infrastructure: [[System - Priority Queue Architecture]], [[System - Pipeline Architecture]], [[System - Four-Stage Creation]]
 - Related: [[Principle - First 72 Hours]] — tension resolved through sequencing

--- a/docs/context-library/rationale/principles/Principle - Compression and Release.md
+++ b/docs/context-library/rationale/principles/Principle - Compression and Release.md
@@ -6,7 +6,7 @@ The portal pattern -- three ingredients for any threshold moment. Compression: t
 
 ## WHERE: Ecosystem
 
-- Advances: [[Strategy - Spatial Visibility]] -- the map reveal IS a compression-release threshold
+- Advances: [[Product Thesis - Spatial Visibility]] -- the map reveal IS a compression-release threshold
 - Related: [[Principle - Action Before Explanation]] -- compression obscures what's coming; the reveal teaches through experience, not narration
 - Related: [[Principle - The WOW Chain]] -- the portal is beat #0 that opens the chain
 - Related: [[Zone - Life Map]] -- first reveal is the release moment
@@ -16,7 +16,7 @@ The portal pattern -- three ingredients for any threshold moment. Compression: t
 
 ## WHY: Belief
 
-- Strategy: [[Strategy - Spatial Visibility]] -- spatial impact requires emotional contrast; the map reveal means nothing without compression first
+- Product Thesis: [[Product Thesis - Spatial Visibility]] -- spatial impact requires emotional contrast; the map reveal means nothing without compression first
 - Driver: Derived from Frank Lloyd Wright's architectural compression-release pattern. Without compression, the map reveal is just a screen loading. WITH compression -- the intimate moment with Jarvis, the single question, the brief enclosed space -- the map reveal becomes a gasp. The gasp is what opens the attention that makes everything after it stick. Examples: Myst (library to island), Breath of the Wild (cave to Hyrule), a forest path narrowing before opening onto a hidden lake.
 
 ## WHEN: Timeline

--- a/docs/context-library/rationale/principles/Principle - Earn Don't Interrogate.md
+++ b/docs/context-library/rationale/principles/Principle - Earn Don't Interrogate.md
@@ -7,7 +7,7 @@ Knowledge acquisition must never block progress, must feel helpful rather than i
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - AI as Teammates]]
+- Advances: [[Product Thesis - AI as Teammates]]
 - Governs: All agent knowledge acquisition, [[Artifact - The Charter]], [[Artifact - The Agenda]], [[System - Progressive Knowledge Capture]], [[System - Smoke Signals]]
 - Agents: [[Agent - Jarvis]], [[Agent - Mesa]], [[Agent - Marvin]], [[Agent - Conan]]
 - Companion detail: Builder Knowledge & Intelligence System (companion document)

--- a/docs/context-library/rationale/principles/Principle - Empty Slots Strategic.md
+++ b/docs/context-library/rationale/principles/Principle - Empty Slots Strategic.md
@@ -7,7 +7,7 @@ An empty Gold or Silver slot can be a deliberate choice — to recover, catch up
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - Superior Process]]
+- Advances: [[Product Thesis - Superior Process]]
 - Governs: [[Overlay - The Table]] (visual treatment of empty slots), [[Component - Gold Position]], [[Component - Silver Position]]
 - Implemented by: [[Standard - Table Slot Behaviors]] — makes intentional emptiness testable
 - Agents: [[Agent - Marvin]] (respects empty choices), [[Agent - Jarvis]] (strategic framing)

--- a/docs/context-library/rationale/principles/Principle - Familiarity Over Function.md
+++ b/docs/context-library/rationale/principles/Principle - Familiarity Over Function.md
@@ -7,7 +7,7 @@ Builders classify work by how it feels to them, not by objective criteria — th
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - Superior Process]], [[Strategy - AI as Teammates]]
+- Advances: [[Product Thesis - Superior Process]], [[Product Thesis - AI as Teammates]]
 - Governs: [[Capability - Purpose Assignment]], [[Standard - Priority Score]], [[Room - Sorting Room]], [[System - Weekly Priority]]
 - Agents: [[Agent - Marvin]] (priority recommendations and purpose capture during creation)
 - Related: [[Principle - Earn Don't Interrogate]] — both respect builder sovereignty

--- a/docs/context-library/rationale/principles/Principle - First 72 Hours.md
+++ b/docs/context-library/rationale/principles/Principle - First 72 Hours.md
@@ -9,7 +9,7 @@ The first five minutes are the critical path. The portal, the wow chain, and the
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - AI as Teammates]] — first impressions of the team matter
+- Advances: [[Product Thesis - AI as Teammates]] — first impressions of the team matter
 - Related: [[Principle - Earn Don't Interrogate]] — progressive capture, not forms
 - Related: [[Principle - Action Before Explanation]] -- first action within 15 seconds
 - Related: [[Principle - Compression and Release]] -- the portal opens the 72-hour window
@@ -22,7 +22,7 @@ The first five minutes are the critical path. The portal, the wow chain, and the
 
 ## WHY: Belief
 
-- Strategy: [[Strategy - AI as Teammates]] — first impressions of the team matter
+- Product Thesis: [[Product Thesis - AI as Teammates]] — first impressions of the team matter
 - Driver: New users abandon tools that feel overwhelming or empty. The first 72 hours must create momentum and understanding simultaneously.
 
 ## WHEN: Timeline

--- a/docs/context-library/rationale/principles/Principle - Guide When Helpful.md
+++ b/docs/context-library/rationale/principles/Principle - Guide When Helpful.md
@@ -7,7 +7,7 @@ All capabilities are always available to find — active guidance follows the bu
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - AI as Teammates]]
+- Advances: [[Product Thesis - AI as Teammates]]
 - Governs: Feature discoverability, [[Capability - Workspace Navigation]], [[Agent - Mesa]] (routing behavior)
 - Rooms: [[Room - Council Chamber]], [[Room - Drafting Room]], [[Room - Sorting Room]], [[Room - Roster Room]]
 - Related: [[Principle - First 72 Hours]] — first 72 hours need more active guidance than steady state

--- a/docs/context-library/rationale/principles/Principle - Plans Are Hypotheses.md
+++ b/docs/context-library/rationale/principles/Principle - Plans Are Hypotheses.md
@@ -7,7 +7,7 @@ A weekly plan is a bet, not a commitment — adapting mid-week is engaged leader
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - Superior Process]]
+- Advances: [[Product Thesis - Superior Process]]
 - Governs: [[System - Adaptation]], [[System - Weekly Priority]], [[Room - Sorting Room]], [[Room - Council Chamber]]
 - Implemented by: [[Standard - Planning Calibration]] — makes hypothesis framing testable
 - Agents: [[Agent - Jarvis]] (tone in reviews), [[Agent - Marvin]] (priority adjustments)

--- a/docs/context-library/rationale/principles/Principle - Protect Transformation.md
+++ b/docs/context-library/rationale/principles/Principle - Protect Transformation.md
@@ -7,7 +7,7 @@ A single ranked priority list lets urgent maintenance perpetually displace impor
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - Superior Process]]
+- Advances: [[Product Thesis - Superior Process]]
 - Governs: [[Capability - Three-Stream Filtering]], [[Overlay - The Table]], [[System - Bronze Operations]], [[Room - Sorting Room]], [[System - Weekly Priority]]
 - Table positions: [[Component - Gold Position]], [[Component - Silver Position]], [[Component - Bronze Position]]
 - Related: [[Principle - Empty Slots Strategic]] — protection includes permission to rest

--- a/docs/context-library/rationale/principles/Principle - The WOW Chain.md
+++ b/docs/context-library/rationale/principles/Principle - The WOW Chain.md
@@ -6,7 +6,7 @@ After a reveal, a sequence of varied surprises prevents deflation. Each wow is a
 
 ## WHERE: Ecosystem
 
-- Advances: [[Strategy - AI as Teammates]] -- wow beats introduce teammates through action, not introduction
+- Advances: [[Product Thesis - AI as Teammates]] -- wow beats introduce teammates through action, not introduction
 - Related: [[Principle - Action Before Explanation]] -- each wow is also a lesson disguised as a surprise
 - Related: [[Principle - Compression and Release]] -- the portal is beat #0 that opens the chain
 - Related: [[Principle - First 72 Hours]] -- wow beats front-load the first session within the 72-hour window
@@ -15,7 +15,7 @@ After a reveal, a sequence of varied surprises prevents deflation. Each wow is a
 
 ## WHY: Belief
 
-- Strategy: [[Strategy - AI as Teammates]] -- teammates are introduced through their actions, which are surprises in themselves
+- Product Thesis: [[Product Thesis - AI as Teammates]] -- teammates are introduced through their actions, which are surprises in themselves
 - Driver: After a huge reveal, there's a risk of deflation -- the blank canvas problem. If nothing follows the portal, the feeling fades fast. The wow chain keeps attention alive. God of War follows the axe recall with combat, then a companion, then a boss -- each a different kind of surprise. Animal Crossing follows the island reveal with a furniture tree, then a pun fish, then naming the island. Without the chain, the reveal is a peak followed by a cliff.
 
 ## WHEN: Timeline

--- a/docs/context-library/rationale/principles/Principle - Visibility Creates Agency.md
+++ b/docs/context-library/rationale/principles/Principle - Visibility Creates Agency.md
@@ -7,7 +7,7 @@ Builders can't control what they can't see — spatial visibility creates compre
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - Spatial Visibility]]
+- Advances: [[Product Thesis - Spatial Visibility]]
 - Governs: [[Zone - Life Map]], [[Overlay - The Table]], [[Structure - Hex Grid]], [[Capability - Zoom Navigation]], [[Room - Project Board]], [[Room - System Board]]
 - Zoom tiers: [[Capability - Zoom Navigation]]
 - Related: [[Principle - Visual Recognition]] — visibility must also be instantly legible

--- a/docs/context-library/rationale/principles/Principle - Visual Recognition.md
+++ b/docs/context-library/rationale/principles/Principle - Visual Recognition.md
@@ -7,7 +7,7 @@ A builder must immediately recognize what each visual element represents without
 ## WHERE: Ecosystem
 
 - Type: Design Principle
-- Advances: [[Strategy - Spatial Visibility]]
+- Advances: [[Product Thesis - Spatial Visibility]]
 - Governs: [[Primitive - Project]], [[Primitive - System]], [[Structure - Hex Grid]], [[Component - Hex Tile]]
 - Companion detail: Brand Standards v2
 - Related: [[Principle - Visibility Creates Agency]] — visibility must also be instantly legible

--- a/docs/context-library/rationale/product-thesis/Product Thesis - AI as Teammates.md
+++ b/docs/context-library/rationale/product-thesis/Product Thesis - AI as Teammates.md
@@ -1,12 +1,16 @@
-# Strategy - AI as Teammates
+# Product Thesis - AI as Teammates
 
-## WHAT: The Strategy
+## WHAT: The Thesis
 
-Agents with defined jobs, permissions, and coordination capabilities provide leverage previously available only to people with human staff. This is Strategic Plank 3 — the third of three independent bets LifeBuild is built on.
+Agents with defined jobs, permissions, and coordination capabilities provide leverage previously available only to people with human staff. This is Plank 3 — the third of three independent bets LifeBuild is built on.
+
+Counter-thesis: The "teammate" framing is anthropomorphic wishful thinking. AI is a tool, and the most effective tools are general-purpose, not role-specialized. Users will prefer one powerful general assistant over a team of specialized agents with limited authority — the coordination overhead of multiple agents exceeds the specialization benefit.
 
 ## WHERE: Ecosystem
 
-- Type: Strategic Bet
+- Type: Product Thesis (Plank)
+- Parent: [[Product Thesis - The Organized Life]]
+- Problem: [[Product Thesis - Organizational Life]]
 - Implementing principles: [[Principle - Earn Don't Interrogate]], [[Principle - Guide When Helpful]]
 - Core team: [[Agent - Jarvis]], [[Agent - Marvin]], [[Agent - Conan]]. Reserve: [[Agent - Mesa]]
 - Systems: [[Standard - Service Levels]], [[Standard - Knowledge Framework]], [[System - Processing Layer]]
@@ -61,6 +65,17 @@ The bet: if builders have AI agents with defined jobs, appropriate permissions, 
 ### Decision Heuristic
 
 When choosing between the builder doing work personally and delegating to an agent, delegate — but only within the agent's defined role and earned authority level, never beyond it.
+
+## Validation Criteria
+
+To validate the teammate bet, measure whether role-differentiated agents outperform generic assistance, and whether users develop trust patterns that enable progressive delegation.
+
+- **Role-appropriate delegation:** After 30 days, do users direct operational questions to Marvin and strategic questions to Jarvis, or do they use agents interchangeably? Measure the percentage of interactions that match the agent's defined role. Target: >60% role-matched interactions. If users treat all agents as generic chat, the role differentiation isn't creating value.
+- **Acceptance rate by authority level:** Track what percentage of agent suggestions/actions are accepted at each authority tier. Level 1 (reactive help) acceptance should be high (>80%). If users reject most agent output even at the lowest authority level, the trust foundation isn't forming.
+- **Permission escalation rate:** What percentage of users voluntarily grant agents expanded permissions (moving from "suggest" to "draft" to "execute") within 90 days? Target: >20% of active users escalate at least once. This is the trust ladder in action — if nobody climbs, the progressive trust model isn't working.
+- **Generic reversion test:** Give users access to both role-specific agents and a generic "ask anything" assistant. After 60 days, what percentage of interactions go to role-specific agents vs. the generic option? If generic wins, specialization isn't worth the complexity.
+- **Time-to-delegation:** How long after onboarding before a user delegates a task they previously would have done themselves (not just asks a question, but hands off actual work)? Target: within 14 days for at least one task type. If users never cross from "asking for help" to "delegating work," the teammate thesis isn't landing.
+- **Invalidation signal:** Users treat agents as interchangeable chat interfaces, don't escalate permissions, or revert to doing work themselves because delegation overhead exceeds the time saved.
 
 ## Tensions
 

--- a/docs/context-library/rationale/product-thesis/Product Thesis - Organizational Life.md
+++ b/docs/context-library/rationale/product-thesis/Product Thesis - Organizational Life.md
@@ -1,0 +1,36 @@
+# Product Thesis - Organizational Life
+
+## WHAT: The Thesis
+
+The modern knowledge worker's life has the organizational complexity of a company but none of the organizational infrastructure. People juggle careers, finances, health, relationships, creative projects, and household logistics across fragmented tools with no integration layer, no capacity management, and no coordination support. This isn't a productivity problem — it's an infrastructure problem. The diagnosis: life is organizational, but people lack organizational tools built for whole-life scope.
+
+Counter-thesis: Life isn't organizational — it's spontaneous, relational, and resistant to systematization. The people who feel "organizationally overwhelmed" are a niche of type-A productivity enthusiasts, not a mass market. Most people manage fine with calendar + notes + a few domain-specific apps. The "fragmentation" is actually healthy specialization — each tool does its domain well.
+
+## WHERE: Ecosystem
+
+- Type: Product Thesis (Problem)
+- Solution: [[Product Thesis - The Organized Life]]
+- Planks: [[Product Thesis - Spatial Visibility]], [[Product Thesis - Superior Process]], [[Product Thesis - AI as Teammates]]
+
+## WHY: Reasoning
+
+The gap between organizational complexity and organizational support has widened in two directions simultaneously. First, life has become more complex: knowledge workers manage more commitments, across more domains, with more optionality than any previous generation. Second, tools have fragmented further: the average target user manages 4+ distinct tools (calendar, task manager, fitness tracker, finance app, notes, project boards) with no integration layer connecting them.
+
+This creates a specific failure mode: dropping balls not from laziness or poor prioritization, but from inability to see the whole picture. A commitment made in one domain (health) conflicts with a commitment in another (career) — and neither tool knows about the other. The builder can't see their full portfolio of commitments, can't assess their actual capacity, and can't coordinate across domains.
+
+The problem thesis is not "people need better tools." It's "people need infrastructure" — the organizational layer that companies build internally (planning rhythms, role clarity, communication protocols, capacity management) but that doesn't exist for individual life.
+
+## Validation Criteria
+
+To validate the problem, measure whether people experience life management as an organizational challenge and whether existing tools fail at whole-life scope.
+
+- **User interviews (pre-onboarding):** What percentage of prospective users, unprompted, describe life management using organizational language — "juggling," "dropping balls," "can't keep track of everything"? Target: >70% recognition of the problem framing.
+- **Domain fragmentation survey:** How many distinct tools does a target user currently use to manage different life domains? (Calendar for schedule, app for fitness, spreadsheet for finances, notes for projects, etc.) Target: 4+ tools with no integration layer. This validates the "no infrastructure for the whole" claim.
+- **Abandonment interviews:** Among users who try and leave LifeBuild, how many cite "I don't need this level of structure" (problem isn't real for them) vs. "this didn't solve the problem I have" (problem is real, solution is wrong)? The ratio distinguishes problem-thesis failure from solution-thesis failure.
+- **Competitive landscape test:** Do competitors in the space converge on whole-life scope, or do successful products stay domain-specific? Sustained convergence validates the problem; sustained fragmentation challenges it.
+- **Invalidation signal:** Target users consistently say "I manage fine with what I have" or segment cleanly into domain-specific tools without feeling the integration gap.
+
+## WHEN: Timeline
+
+**Build phase:** Foundation (ongoing)
+**Conviction level:** High — the problem framing resonates strongly in interviews and the fragmentation data is observable.

--- a/docs/context-library/rationale/product-thesis/Product Thesis - Spatial Visibility.md
+++ b/docs/context-library/rationale/product-thesis/Product Thesis - Spatial Visibility.md
@@ -1,12 +1,16 @@
-# Strategy - Spatial Visibility
+# Product Thesis - Spatial Visibility
 
-## WHAT: The Strategy
+## WHAT: The Thesis
 
-Making work visual, placed, and traversable creates comprehension and agency that lists and abstractions cannot. This is Strategic Plank 1 — the first of three independent bets LifeBuild is built on.
+Making work visual, placed, and traversable creates comprehension and agency that lists and abstractions cannot. This is Plank 1 — the first of three independent bets LifeBuild is built on.
+
+Counter-thesis: Spatial representation is a novelty that wears off. Lists and search are faster for task execution; spatial views add visual appeal but not comprehension advantage. The brain's spatial memory systems help with physical navigation, not abstract project management — the analogy doesn't transfer.
 
 ## WHERE: Ecosystem
 
-- Type: Strategic Bet
+- Type: Product Thesis (Plank)
+- Parent: [[Product Thesis - The Organized Life]]
+- Problem: [[Product Thesis - Organizational Life]]
 - Implementing principles: [[Principle - Visibility Creates Agency]], [[Principle - Visual Recognition]]
 - Governs: [[Zone - Life Map]], [[Structure - Hex Grid]], [[Overlay - The Table]], [[Capability - Zoom Navigation]], [[Room - Project Board]], [[Room - System Board]]
 - Zoom tiers: [[Capability - Zoom Navigation]]
@@ -58,6 +62,17 @@ Research supports this: the brain's spatial processing and memory systems share 
 ### Decision Heuristic
 
 When choosing between abstract representation and spatial/visual representation, always choose spatial — comprehension through seeing and navigating beats comprehension through reading and thinking.
+
+## Validation Criteria
+
+To validate the spatial bet, measure whether spatial representation creates comprehension advantages over abstract representation, and whether those advantages persist at scale.
+
+- **A/B comprehension test:** Show the same portfolio of 12+ projects in spatial view vs. list view. Ask "what's stalled?" "what's your highest priority?" "what did you forget about?" Measure time-to-answer and accuracy. Target: spatial users answer faster and catch more forgotten/stalled items.
+- **Reversion tracking:** After 30 days of access to both spatial and list views, what percentage of sessions begin in spatial view? Target: >60%. If users consistently navigate to list view first, the spatial bet isn't delivering enough value to change default behavior.
+- **Scale breakpoint:** At what project count does spatial comprehension degrade? Test at 5, 15, 30, and 50+ active items. If spatial advantage disappears below 20 projects, the thesis holds only for power users — which may not be a large enough market.
+- **Recall test:** After a week away, ask users to name their active projects and their status from memory. Compare spatial-primary users vs. list-primary users. Spatial memory encoding predicts that spatial users recall more items and more accurate status.
+- **"I forgot about that" metric:** Track how often users rediscover stalled or forgotten work through spatial browsing that they didn't find through list/search. This is the unique spatial value — ambient awareness through presence rather than active querying.
+- **Invalidation signal:** Users consistently prefer list/search views, spatial comprehension doesn't outperform lists in controlled tests, or the advantage disappears below a project count that represents most users.
 
 ## Tensions
 

--- a/docs/context-library/rationale/product-thesis/Product Thesis - Superior Process.md
+++ b/docs/context-library/rationale/product-thesis/Product Thesis - Superior Process.md
@@ -1,12 +1,16 @@
-# Strategy - Superior Process
+# Product Thesis - Superior Process
 
-## WHAT: The Strategy
+## WHAT: The Thesis
 
-Applying structured frameworks — from basic organization through sophisticated capacity management — to personal life improves execution and decision-making. This is Strategic Plank 2 — the second of three independent bets LifeBuild is built on.
+Applying structured frameworks — from basic organization through sophisticated capacity management — to personal life improves execution and decision-making. This is Plank 2 — the second of three independent bets LifeBuild is built on.
+
+Counter-thesis: People don't want process in their personal lives. Professional project management works because organizations can enforce compliance; individuals will always revert to path-of-least-resistance habits. The overhead of maintaining structure exceeds the execution gains for anyone who isn't already a process enthusiast.
 
 ## WHERE: Ecosystem
 
-- Type: Strategic Bet
+- Type: Product Thesis (Plank)
+- Parent: [[Product Thesis - The Organized Life]]
+- Problem: [[Product Thesis - Organizational Life]]
 - Implementing principles: [[Principle - Protect Transformation]], [[Principle - Plans Are Hypotheses]], [[Principle - Empty Slots Strategic]]
 - Governs: [[Standard - Three-Stream Portfolio]], [[System - Priority Queue Architecture]], [[System - Pipeline Architecture]], [[System - Four-Stage Creation]], [[System - Weekly Priority]], [[Standard - Priority Score]]
 - Systems: [[System - Bronze Operations]], [[System - Adaptation]]
@@ -61,6 +65,17 @@ The bet: if we apply structured process to personal life, builders will execute 
 ### Decision Heuristic
 
 When choosing between ad-hoc response and structured process, choose structure — but only as much structure as the builder's current maturity level can absorb without overhead exceeding value.
+
+## Validation Criteria
+
+To validate the process bet, measure whether structured frameworks improve execution and whether users adopt progressively more structure over time rather than abandoning it.
+
+- **Completion rate tracking:** Compare the percentage of weekly committed work actually completed, before process adoption (baseline from first two weeks) vs. after 60 days of process use. Target: measurable improvement in follow-through, not just capture.
+- **Overwhelm index:** Self-reported overwhelm score (simple 1-5 scale) at onboarding, 30 days, and 90 days. Process should reduce overwhelm. If overwhelm stays flat or increases, the process is adding overhead without reducing cognitive load.
+- **Voluntary maturity climbing:** What percentage of users who start at Level 1-2 (basic capture, kanban) voluntarily adopt Level 3+ features (three-stream portfolio, The Table, WIP limits) within 90 days? Target: >30%. This is the critical signal that process creates pull rather than requiring push.
+- **Overhead ratio:** Time spent maintaining the system (weekly planning, reclassification, review) vs. time saved by it (reduced decision fatigue, fewer dropped commitments, less context-switching). Survey-based initially, instrumented later. If maintenance exceeds perceived savings, the thesis is failing for that user.
+- **30-day process feature retention:** What percentage of users who activate a process feature (The Table, three-stream filtering, WIP limits) are still using it 30 days later? Target: >50%. Below 40% suggests the feature creates novelty engagement but not sustained value.
+- **Invalidation signal:** Users abandon process features within weeks, completion rates don't improve with process adoption, or the overhead ratio is unfavorable for the median user.
 
 ## Tensions
 

--- a/docs/context-library/rationale/product-thesis/Product Thesis - The Organized Life.md
+++ b/docs/context-library/rationale/product-thesis/Product Thesis - The Organized Life.md
@@ -1,0 +1,49 @@
+# Product Thesis - The Organized Life
+
+## WHAT: The Thesis
+
+The combination of spatial visibility, structured process, and AI teammates creates a category of product that doesn't exist yet — personal organizational infrastructure. Each plank delivers independent value, but their intersection produces capabilities none can achieve alone: agents that understand your process and can see your landscape, spatial views that reflect structured priority rather than arbitrary arrangement, process that executes through teammates rather than requiring manual maintenance. The product thesis is that this gestalt — the organized life, supported by infrastructure previously available only inside well-run companies — is categorically different from a better todo app, a prettier dashboard, or a smarter chatbot.
+
+Counter-thesis: Integration is overrated. Best-of-breed wins: people will use the best spatial tool, the best process tool, and the best AI tool separately, and light integrations between them will capture most of the value. The complexity of building all three well in one product creates mediocrity across the board — jack of all trades, master of none. Alternatively: the intersection effects are theoretically appealing but practically marginal. Users engage with one plank and ignore the others.
+
+## WHERE: Ecosystem
+
+- Type: Product Thesis (Solution)
+- Parent: [[Product Thesis - Organizational Life]]
+- Planks: [[Product Thesis - Spatial Visibility]], [[Product Thesis - Superior Process]], [[Product Thesis - AI as Teammates]]
+- Grounding: The three planks map to Autonomy (spatial), Competence (process), and Relatedness (teammates)
+
+## WHY: Reasoning
+
+Each plank addresses a dimension of the organizational life problem, but the intersections are where the product becomes distinctive:
+
+**Spatial + Process:** A spatial view without process is a pretty picture. A process without spatial representation is a spreadsheet. Together, you get a landscape where spatial position, visual state, and process status are fused — the builder sees their Gold project in its place on the map, visually distinct from Silver and Bronze, with status indicators that reflect pipeline stage. Comprehension becomes immediate because the spatial encoding carries process meaning.
+
+**Process + Teammates:** Process without agents means the builder does all the maintenance — updating statuses, running reviews, tracking WIP limits, maintaining the weekly rhythm. That's overhead. Agents without process means delegates with no framework — they can help with individual tasks but can't manage workflow, respect capacity limits, or maintain planning rhythms. Together, agents run the process: Marvin manages the operational pipeline, tracks WIP, and facilitates the weekly cycle. Process becomes something that happens for the builder rather than something the builder maintains.
+
+**Spatial + Teammates:** Agents without spatial context can answer questions but can't see the landscape — they don't know what's adjacent, what's clustered, what the builder hasn't looked at in weeks. Spatial views without agents are passive — the builder sees everything but still has to act on everything themselves. Together, agents can notice spatial patterns (a neglected cluster, an overcrowded zone) and surface them — the landscape becomes actively monitored rather than passively displayed.
+
+**All three:** The fully realized product is an agent team that understands your process, can see your landscape, and acts within both. The builder delegates to a team that operates within a structured framework, visualized spatially. This is what "organizational infrastructure for individual life" actually means in practice — not one tool, but a system.
+
+## Validation Criteria
+
+To validate the solution thesis, measure whether multi-plank engagement produces non-linear improvement over single-plank engagement. The core question: is the whole greater than the sum?
+
+- **Cross-plank engagement correlation:** Do users who engage with Plank 1 adopt Plank 2 features at higher rates than users who don't? Does spatial engagement predict process adoption, and vice versa? If planks are truly synergistic, engagement with one should create pull toward the others. If engagement is independent, the gestalt isn't working.
+- **Multi-plank vs. single-plank outcomes:** Compare completion rates, overwhelm scores, and retention between users engaging with one plank vs. two vs. all three. Target: non-linear improvement — two-plank users should outperform one-plank users by more than 2x on key metrics, not exactly 2x. Linear scaling suggests additive value (fine, but not distinctive). Superlinear scaling validates the gestalt.
+- **Feature interaction usage:** Track usage of features that require plank intersection — e.g., an agent surfacing a spatial insight ("you haven't visited your Health zone in two weeks"), or a spatial view reflecting process state (hex tiles colored by pipeline stage). If intersection features have higher engagement than single-plank features, the gestalt is delivering value users feel.
+- **Competitive differentiation test:** In user interviews, ask what they'd miss most if they had to switch to a competitor. If answers reference intersection capabilities ("Marvin managing my Table for me," "seeing my whole portfolio spatially with priority built in"), the gestalt is the moat. If answers reference single-plank features ("the hex map is pretty," "I like the WIP limits"), the integration isn't the value driver.
+- **Churn analysis by plank engagement:** Do multi-plank users churn at lower rates than single-plank users? And critically: do users who lose a plank (e.g., stop using agents but keep spatial + process) churn at higher rates than expected from that plank's independent value? Higher-than-expected churn suggests the planks reinforce each other — removing one degrades the others.
+- **Invalidation signal:** Multi-plank engagement scales linearly (no gestalt effect), users engage deeply with one plank and ignore others, or intersection features see low adoption compared to single-plank features.
+
+## Exposure
+
+If the solution thesis is wrong — if the combination doesn't create superlinear value — LifeBuild becomes a good-but-not-distinctive productivity tool competing on individual plank quality against specialists. The product survives but the moat disappears. The strategic response would be to identify which plank is strongest, double down on it, and treat the others as supporting rather than co-equal.
+
+The deeper risk: building all three planks simultaneously divides resources three ways. If the gestalt doesn't materialize, you've built three okay things instead of one great thing. This is the jack-of-all-trades failure mode the counter-thesis predicts.
+
+## WHEN: Timeline
+
+**Build phase:** MVP (ongoing)
+**Conviction level:** High on the theoretical argument, untestable until at least two planks reach maturity.
+**Reality note (2026-02-12):** Cannot validate the solution thesis yet. Process is at Level 3, Spatial is at Level 1, AI Teammates is at Level 1. The intersection effects require at least two planks at functional maturity to measure. Earliest testable: when Spatial reaches Level 2 and intersects with existing Process infrastructure.

--- a/docs/context-library/rationale/standards/Standard - Bronze Mode Behaviors.md
+++ b/docs/context-library/rationale/standards/Standard - Bronze Mode Behaviors.md
@@ -13,7 +13,7 @@ The specification for three Bronze stack operating modes — Minimal, Target, an
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — operational work managed with flexible controls
+- Product Thesis: [[Product Thesis - Superior Process]] — operational work managed with flexible controls
 - Principle: [[Principle - Protect Transformation]] — modes let builders constrain Bronze expansion
 - Driver: Different weeks need different operational engagement. Modes provide that flexibility.
 

--- a/docs/context-library/rationale/standards/Standard - Dual Presence.md
+++ b/docs/context-library/rationale/standards/Standard - Dual Presence.md
@@ -14,7 +14,7 @@ The specification for how Work at Hand projects appear in two places simultaneou
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — work has spatial location AND priority status
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — work has spatial location AND priority status
 - Principle: [[Principle - Visibility Creates Agency]] — builder sees both where work lives (grid) and that it's prioritized (Table)
 - Decision: Same object rendered twice, not two objects synced. Ensures consistency.
 

--- a/docs/context-library/rationale/standards/Standard - Image Evolution.md
+++ b/docs/context-library/rationale/standards/Standard - Image Evolution.md
@@ -14,7 +14,7 @@ The specification for the five-stage visual progression of a project's illustrat
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — visual distinctiveness enables spatial memory
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — visual distinctiveness enables spatial memory
 - Principle: [[Principle - Visual Recognition]] — two-second identification test
 - Decision: Content-depicting diorama-style illustrations over abstract patterns. By Colored stage, builder should recognize "that's my kitchen project" from across the room.
 

--- a/docs/context-library/rationale/standards/Standard - Knowledge Framework.md
+++ b/docs/context-library/rationale/standards/Standard - Knowledge Framework.md
@@ -9,14 +9,14 @@ The specification for organizing everything the AI team learns about a builder �
 - Implemented by: [[System - Progressive Knowledge Capture]] — acquires knowledge
 - Implemented by: [[System - Processing Layer]] — computes patterns
 - Implements: [[Principle - Earn Don't Interrogate]] — acquisition philosophy
-- Advances: [[Strategy - AI as Teammates]] — knowledge enables relationship depth
+- Advances: [[Product Thesis - AI as Teammates]] — knowledge enables relationship depth
 - Feeds: [[Standard - Service Levels]] — knowledge depth determines service quality
 - Used by: [[Agent - Jarvis]] — orchestrates knowledge gathering
 - Conforming: [[Artifact - The Charter]] — content maps to knowledge domains
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — teammates know you, tools don't
+- Product Thesis: [[Product Thesis - AI as Teammates]] — teammates know you, tools don't
 - Principle: [[Principle - Earn Don't Interrogate]] — knowledge earned through relationship, not demanded upfront
 - Decision: Seven domains capture comprehensive understanding without overwhelming complexity.
 

--- a/docs/context-library/rationale/standards/Standard - Life Categories.md
+++ b/docs/context-library/rationale/standards/Standard - Life Categories.md
@@ -16,7 +16,7 @@ The specification for the eight default life-domain categories that organize all
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — categories are the primary spatial organizing dimension
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — categories are the primary spatial organizing dimension
 - Principle: [[Principle - Familiarity Over Function]] — this standard makes "categories should feel immediately recognizable" testable
 - Driver: Builders need a familiar framework for sorting life's work. Derived from a comparative survey of established frameworks (Wheel of Life, Robbins' categories) selecting the most consistently-appearing domains across frameworks. Familiarity over novelty — builders should recognize categories immediately, not learn a new taxonomy.
 - Decision: Eight defaults, not immutable. Defaults anchor the Life Map's visual structure and provide familiar starting points. Customization is permitted because the builder's mental model takes priority over system convenience.

--- a/docs/context-library/rationale/standards/Standard - Priority Score.md
+++ b/docs/context-library/rationale/standards/Standard - Priority Score.md
@@ -17,7 +17,7 @@ The specification for computing priority ranking within streams: base formula pl
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — systematic prioritization support
+- Product Thesis: [[Product Thesis - Superior Process]] — systematic prioritization support
 - Driver: Without stream weighting, the formula would rank Gold and Bronze on same criteria. Weightings encode philosophy: Gold amplifies Importance, Bronze amplifies Urgency, Silver rewards Leverage.
 - Decision: Formula is hypothesis, not validated algorithm. Expect tuning based on override frequency and builder feedback.
 

--- a/docs/context-library/rationale/standards/Standard - Project States.md
+++ b/docs/context-library/rationale/standards/Standard - Project States.md
@@ -13,7 +13,7 @@ The specification for lifecycle stages a project moves through from initial capt
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — clear lifecycle enables structured management
+- Product Thesis: [[Product Thesis - Superior Process]] — clear lifecycle enables structured management
 - Principle: [[Principle - Visibility Creates Agency]] — state visible at a glance
 - Driver: Builders need to know where each project stands and what they can do with it.
 

--- a/docs/context-library/rationale/standards/Standard - Service Levels.md
+++ b/docs/context-library/rationale/standards/Standard - Service Levels.md
@@ -9,14 +9,14 @@ The specification for the progressive ladder (Levels 0-5) measuring how well the
 - Implemented by: [[Standard - Knowledge Framework]] — organizes knowledge
 - Implemented by: [[System - Progressive Knowledge Capture]] — acquires knowledge
 - Implements: [[Principle - Compound Capability]] — service compounds over time
-- Advances: [[Strategy - AI as Teammates]] — relationship depth creates value
+- Advances: [[Product Thesis - AI as Teammates]] — relationship depth creates value
 - Used by: [[Agent - Jarvis]] — orchestrates progression
 - Conforming systems: [[System - Service Level Progression]] — UI for level display and progression
 - Related: [[Artifact - The Charter]] — living knowledge store
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - AI as Teammates]] — the difference between tool and teammate is knowledge depth
+- Product Thesis: [[Product Thesis - AI as Teammates]] — the difference between tool and teammate is knowledge depth
 - Principle: [[Principle - Compound Capability]] — month-12 service should be dramatically better than month-1
 - Decision: Six levels provide clear progression markers without false precision.
 

--- a/docs/context-library/rationale/standards/Standard - Smoke Signal Thresholds.md
+++ b/docs/context-library/rationale/standards/Standard - Smoke Signal Thresholds.md
@@ -14,7 +14,7 @@ The specification for trigger conditions, visual treatments, and dismissal rules
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — ambient signals leverage spatial awareness
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — ambient signals leverage spatial awareness
 - Principle: [[Principle - Visibility Creates Agency]] — builders see problems early
 - Principle: [[Principle - Guide When Helpful]] — helpful signals, not nagging alerts
 - Driver: Builders need awareness without bombardment. Smoke Signals make problems visible without demanding immediate action.

--- a/docs/context-library/rationale/standards/Standard - Three-Stream Portfolio.md
+++ b/docs/context-library/rationale/standards/Standard - Three-Stream Portfolio.md
@@ -15,7 +15,7 @@ The specification for classifying all builder work into three purpose-based stre
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Superior Process]] — applies structured framework to prevent urgency bias
+- Product Thesis: [[Product Thesis - Superior Process]] — applies structured framework to prevent urgency bias
 - Driver: Neurological reality — the brain's threat-detection system responds to urgent/concrete faster than prefrontal cortex evaluates important/abstract. A single ranked list lets urgency always win.
 - Decision: Three streams aren't three lists — they're three separate competitions. Gold competes with Gold on importance. Bronze competes with Bronze on urgency. Cross-type competition is structurally prevented.
 

--- a/docs/context-library/rationale/standards/Standard - Visual Language.md
+++ b/docs/context-library/rationale/standards/Standard - Visual Language.md
@@ -10,13 +10,13 @@ The specification for visual vocabulary across all LifeBuild interfaces — cate
 - Conforming components: [[Component - Hex Tile]], [[Component - Gold Position]], [[Component - Silver Position]], [[Component - Bronze Position]]
 - Implements: [[Principle - Visual Recognition]] — instant identification without inspection
 - Implements: [[Principle - Visibility Creates Agency]] — state visible at a glance
-- Advances: [[Strategy - Spatial Visibility]] — spatial organization requires visual clarity
+- Advances: [[Product Thesis - Spatial Visibility]] — spatial organization requires visual clarity
 - Related: [[Standard - Image Evolution]] — project illustration progression
 - Related: [[Standard - Life Categories]] — category-to-color mapping
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy - Spatial Visibility]] — visibility requires legibility
+- Product Thesis: [[Product Thesis - Spatial Visibility]] — visibility requires legibility
 - Principle: [[Principle - Visual Recognition]] — two-second identification test
 - Decision: Content-depicting illustrations over abstract patterns. Recognition trumps beauty.
 

--- a/docs/context-library/reference.md
+++ b/docs/context-library/reference.md
@@ -8,7 +8,7 @@ Lookup tables for building and auditing Context Library cards.
 
 ```
 WHY we build things?
-├─ Guiding philosophy → STRATEGY
+├─ Product thesis (problem, solution, plank) → PRODUCT THESIS
 ├─ Judgment guidance → PRINCIPLE
 └─ Testable specification → STANDARD
 
@@ -51,7 +51,7 @@ WHAT ships?
 
 **Step 1: Is this about WHY we build?**
 
-- Guiding philosophy (a bet) → Strategy
+- Product thesis (problem, solution, or plank) → Product Thesis
 - Judgment guidance (a rule of thumb) → Principle
 - Testable spec (concrete rules) → Standard
 
@@ -219,7 +219,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 | Card types                              | Status values                                        |
 | --------------------------------------- | ---------------------------------------------------- |
-| Strategy, Principle                     | `experimental` \| `evolving` \| `stable`             |
+| Product Thesis, Principle               | `experimental` \| `evolving` \| `stable`             |
 | Standard                                | `draft` \| `active` \| `deprecated`                  |
 | Product layer (Zone through Agent)      | `core` \| `evolving` \| `proposed`                   |
 | Experience layer (Loop through Dynamic) | `core` \| `evolving` \| `proposed`                   |
@@ -233,29 +233,36 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## Templates
 
-### Strategy
+### Product Thesis
 
 ```markdown
-# Strategy - [Name]
+# Product Thesis - [Name]
 
-## WHAT: The Strategy
+## WHAT: The Thesis
 
-[One sentence articulating the bet. What we believe will work.]
+[One sentence articulating the thesis. For planks: the bet. For problem: the diagnosis. For solution: the gestalt.]
+
+Counter-thesis: [The strongest argument against this thesis.]
 
 ## WHERE: Ecosystem
 
+- Type: Product Thesis (Problem | Solution | Plank)
+- Parent: [[Product Thesis]] — [relationship to parent thesis]
+- Planks: [[Product Thesis]] — [if solution, what planks support it]
 - Principles:
   - [[Principle]] — [what judgment guidance this generates]
 - Standards:
   - [[Standard]] — [what specifications this generates]
 - Zones:
   - [[Zone]] — [what product areas embody this]
-- Tensions:
-  - [[Strategy]] — [what other strategies this trades off against]
 
 ## WHY: Belief
 
-[2-4 sentences. The reasoning behind this bet. What evidence or intuition supports it. What user truth it's grounded in.]
+[2-4 sentences. The reasoning behind this thesis. What evidence or intuition supports it. What user truth it's grounded in.]
+
+## Validation Criteria
+
+[How to validate this thesis. Specific metrics, tests, targets, and invalidation signals.]
 
 ## WHEN: Timeline
 
@@ -264,16 +271,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ### Reality ([YYYY-MM-DD])
 
-[Is this strategy being followed? What evidence exists? What's diverging?]
-
-### History
-
-> **YYYY-MM-DD — [Title]**
-> [What changed and why.]
-
-### Implications
-
-[What divergence from this strategy means for builders. Omit when stable.]
+[Is this thesis holding? What evidence exists? What's diverging?]
 
 ## HOW: Application
 
@@ -287,7 +285,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ### Decision Heuristic
 
-[When facing a tradeoff, how does this strategy guide the choice?]
+[When facing a tradeoff, how does this thesis guide the choice?]
 ```
 
 ---
@@ -303,8 +301,8 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHERE: Ecosystem
 
-- Strategy:
-  - [[Strategy]] — [what bet this serves]
+- Product Thesis:
+  - [[Product Thesis]] — [what bet this serves]
 - Standards:
   - [[Standard]] — [what specifications make this testable]
 - Governs:
@@ -474,7 +472,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Driver: [Why builders need this entity. What problem it solves.]
 
@@ -563,7 +561,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [what bet this embodies]
+- Product Thesis: [[Product Thesis]] — [what bet this embodies]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Separation: [Why this is distinct from other zones. What cognitive mode it serves.]
 
@@ -648,7 +646,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Separation: [Why this is its own room. What JTBD it serves.]
 
@@ -732,7 +730,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Persistence: [Why this must be always-visible. What breaks if hidden.]
 
@@ -977,7 +975,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Purpose: [What builders use this artifact for. What problem it solves.]
 
@@ -1066,7 +1064,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Purpose: [Why builders need to do this. What goal it serves.]
 
@@ -1153,7 +1151,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Gap: [What breaks without this. What problem it solves invisibly.]
 
@@ -1240,7 +1238,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes behavior]
 - Gap: [What breaks without this agent. What need they fill.]
 
@@ -1416,7 +1414,7 @@ Omit section when reality matches vision — no gap, no implications.]
 ## WHERE: Ecosystem
 
 - Parent strategy:
-  - [[Strategy]] — [what bet this division serves]
+  - [[Product Thesis]] — [what bet this division serves]
 - Agents:
   - [[Agent]] — [who staffs this division and in what role]
 - Systems:
@@ -1430,7 +1428,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Rationale
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Separation: [Why this is its own division. What operating model differences justify the separation.]
 
@@ -1613,7 +1611,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Driver: [What engagement pattern this creates. What the builder gains from completing one cycle.]
 
@@ -1703,7 +1701,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Driver: [What growth this journey produces. What the builder gains.]
 
@@ -1786,7 +1784,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: Purpose
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Driver: [Why this feeling matters. What it signals about the builder's state.]
 
@@ -1942,7 +1940,7 @@ Omit section when reality matches vision — no gap, no implications.]
   - [[System]] — [how it shapes this]
 - Governed by:
   - [[Principle]] — [what guided the choice]
-  - [[Strategy]] — [what bet it serves]
+  - [[Product Thesis]] — [what bet it serves]
 - Generates:
   - [[Principle]] — [if this decision became a principle]
   - [[Standard]] — [if this decision became a standard]
@@ -2043,7 +2041,7 @@ Omit section when reality matches vision — no gap, no implications.]
 
 ## WHY: The Driver
 
-- Strategy: [[Strategy]] — [alignment]
+- Product Thesis: [[Product Thesis]] — [alignment]
 - Principle: [[Principle]] — [guidance]
 - Trigger: [What prompted this initiative. Metric, enterprise context, opportunity.]
 
@@ -2189,7 +2187,7 @@ Releases use **planning mode** (forward-looking) while being built and **retrosp
 
 ## WHY: Driver
 
-- Strategy: [[Strategy]] — [what bet this serves]
+- Product Thesis: [[Product Thesis]] — [what bet this serves]
 - Principle: [[Principle]] — [what guidance shapes it]
 - Trigger: [What's prompting this. Metric, opportunity, request.]
 
@@ -2248,7 +2246,7 @@ Releases use **planning mode** (forward-looking) while being built and **retrosp
 
 ```
 /rationale/
-  strategies/
+  product-thesis/
   principles/
   standards/
 
@@ -2296,7 +2294,7 @@ CONVENTIONS.md
 
 | Type             | Pattern                          | Example                                      |
 | ---------------- | -------------------------------- | -------------------------------------------- |
-| Strategy         | Strategy - [Name]                | Strategy - Spatial Visibility                |
+| Product Thesis   | Product Thesis - [Name]          | Product Thesis - Spatial Visibility          |
 | Principle        | Principle - [Name]               | Principle - Visual Recognition               |
 | Standard         | Standard - [Name]                | Standard - Visual Language                   |
 | Primitive        | Primitive - [Name]               | Primitive - Project                          |
@@ -2366,7 +2364,7 @@ Cards touching governed domains must link to constraining Standards.
 | Loop       | Room(s), Capability(s)         | What it contains                          |
 | Journey    | Loop(s), Room(s)               | What it spans                             |
 | Aesthetic  | Room(s), Loop(s), Component(s) | Where it applies                          |
-| Division   | Strategy, Agent(s), System(s)  | What it serves, who staffs, what supports |
+| Division   | Product Thesis, Agent(s), System(s) | What it serves, who staffs, what supports |
 | Playbook   | Division(s), Standard(s)       | Where it's used, what constrains it       |
 | Dynamic    | System(s)                      | What produces it                          |
 
@@ -2397,7 +2395,7 @@ Every link must have context. No naked links.
 | Source Type           | Extract                                                      |
 | --------------------- | ------------------------------------------------------------ |
 | SOT + companion docs  | Zone/Room definitions, capability specs, strategic reasoning |
-| Strategy/vision docs  | Strategy, Principle, Initiative goals                        |
+| Strategy/vision docs  | Product Thesis, Principle, Initiative goals                  |
 | Brand standards docs  | Standards (colors, typography, illustration rules)           |
 | Roadmap/planning docs | Future state, phasing, dependencies                          |
 | Design docs/PRDs      | Capability specs, user scenarios, edge cases                 |

--- a/docs/context-library/reference.md
+++ b/docs/context-library/reference.md
@@ -2352,21 +2352,21 @@ Cards touching governed domains must link to constraining Standards.
 
 ## Containment Relationships
 
-| Type       | Must Link To                   | Relationship                              |
-| ---------- | ------------------------------ | ----------------------------------------- |
-| Room       | Zone                           | Parent workspace                          |
-| Structure  | Room                           | Where it lives                            |
-| Component  | Structure or Room or Overlay   | Parent element                            |
-| Artifact   | Room                           | Where it's edited                         |
-| Capability | Room(s)                        | Where it's performed                      |
-| Prompt     | Agent                          | What it implements                        |
-| Overlay    | Zone(s)                        | Where it's visible                        |
-| Loop       | Room(s), Capability(s)         | What it contains                          |
-| Journey    | Loop(s), Room(s)               | What it spans                             |
-| Aesthetic  | Room(s), Loop(s), Component(s) | Where it applies                          |
+| Type       | Must Link To                        | Relationship                              |
+| ---------- | ----------------------------------- | ----------------------------------------- |
+| Room       | Zone                                | Parent workspace                          |
+| Structure  | Room                                | Where it lives                            |
+| Component  | Structure or Room or Overlay        | Parent element                            |
+| Artifact   | Room                                | Where it's edited                         |
+| Capability | Room(s)                             | Where it's performed                      |
+| Prompt     | Agent                               | What it implements                        |
+| Overlay    | Zone(s)                             | Where it's visible                        |
+| Loop       | Room(s), Capability(s)              | What it contains                          |
+| Journey    | Loop(s), Room(s)                    | What it spans                             |
+| Aesthetic  | Room(s), Loop(s), Component(s)      | Where it applies                          |
 | Division   | Product Thesis, Agent(s), System(s) | What it serves, who staffs, what supports |
-| Playbook   | Division(s), Standard(s)       | Where it's used, what constrains it       |
-| Dynamic    | System(s)                      | What produces it                          |
+| Playbook   | Division(s), Standard(s)            | Where it's used, what constrains it       |
+| Dynamic    | System(s)                           | What produces it                          |
 
 ---
 

--- a/docs/context-library/releases/Release - Context Readiness Assessment.md
+++ b/docs/context-library/releases/Release - Context Readiness Assessment.md
@@ -25,7 +25,7 @@
 - `docs/context-library/rationale/standards/Standard - Visual Language.md`
 - `docs/context-library/rationale/standards/Standard - Spatial Interaction Rules.md`
 - `docs/context-library/rationale/standards/Standard - Life Categories.md`
-- `docs/context-library/rationale/strategies/Strategy - Spatial Visibility.md`
+- `docs/context-library/rationale/product-thesis/Product Thesis - Spatial Visibility.md`
 - `docs/context-library/experience/aesthetics/Aesthetic - Sanctuary.md`
 
 **What the library covers well:**
@@ -67,7 +67,7 @@
 - `docs/context-library/product/agents/Agent - Marvin.md`
 - `docs/context-library/product/rooms/Room - Council Chamber.md`
 - `docs/context-library/product/standards/Standard - Naming Architecture.md`
-- `docs/context-library/rationale/strategies/Strategy - AI as Teammates.md`
+- `docs/context-library/rationale/product-thesis/Product Thesis - AI as Teammates.md`
 
 **What the library covers well:**
 
@@ -352,7 +352,7 @@
 - `docs/context-library/product/agents/Agent - Marvin.md`
 - `docs/context-library/product/agents/Agent - Mesa.md`
 - `docs/context-library/product/standards/Standard - Naming Architecture.md`
-- `docs/context-library/rationale/strategies/Strategy - AI as Teammates.md`
+- `docs/context-library/rationale/product-thesis/Product Thesis - AI as Teammates.md`
 - `docs/context-library/rationale/principles/Principle - Earn Don't Interrogate.md`
 - `docs/context-library/experience/aesthetics/Aesthetic - Being Known.md`
 - `docs/context-library/experience/aesthetics/Aesthetic - Stewardship.md`

--- a/docs/context-library/releases/Release - The Art.md
+++ b/docs/context-library/releases/Release - The Art.md
@@ -79,14 +79,14 @@ The map becomes deeply personal. AI-generated isometric sprites replace the pre-
 
 ## AFFECTED LIBRARY CARDS
 
-| Card                               | How It's Affected                                        |
-| ---------------------------------- | -------------------------------------------------------- |
-| [[Standard - Image Evolution]]     | Fully implemented (3-5 stages)                           |
-| [[Standard - Visual Language]]     | Fully expressed — consistent isometric style             |
-| [[Component - Hex Tile]]           | Rich rendering with generated art + evolution            |
-| [[Product Thesis - Spatial Visibility]]  | Approaching full vision (L4)                             |
-| [[Aesthetic - Accomplishment]]     | Expressed through art evolution — effort becomes visible |
-| [[Principle - Visual Recognition]] | Fully expressed — content-depicting, recognizable art    |
+| Card                                    | How It's Affected                                        |
+| --------------------------------------- | -------------------------------------------------------- |
+| [[Standard - Image Evolution]]          | Fully implemented (3-5 stages)                           |
+| [[Standard - Visual Language]]          | Fully expressed — consistent isometric style             |
+| [[Component - Hex Tile]]                | Rich rendering with generated art + evolution            |
+| [[Product Thesis - Spatial Visibility]] | Approaching full vision (L4)                             |
+| [[Aesthetic - Accomplishment]]          | Expressed through art evolution — effort becomes visible |
+| [[Principle - Visual Recognition]]      | Fully expressed — content-depicting, recognizable art    |
 
 ---
 

--- a/docs/context-library/releases/Release - The Art.md
+++ b/docs/context-library/releases/Release - The Art.md
@@ -84,7 +84,7 @@ The map becomes deeply personal. AI-generated isometric sprites replace the pre-
 | [[Standard - Image Evolution]]     | Fully implemented (3-5 stages)                           |
 | [[Standard - Visual Language]]     | Fully expressed — consistent isometric style             |
 | [[Component - Hex Tile]]           | Rich rendering with generated art + evolution            |
-| [[Strategy - Spatial Visibility]]  | Approaching full vision (L4)                             |
+| [[Product Thesis - Spatial Visibility]]  | Approaching full vision (L4)                             |
 | [[Aesthetic - Accomplishment]]     | Expressed through art evolution — effort becomes visible |
 | [[Principle - Visual Recognition]] | Fully expressed — content-depicting, recognizable art    |
 

--- a/docs/context-library/releases/Release - The Attendants.md
+++ b/docs/context-library/releases/Release - The Attendants.md
@@ -88,7 +88,7 @@ The builder stops doing everything alone. Attendant agents — specialist AI wor
 | ---------------------------------- | ----------------------------------------- |
 | [[Room - Roster Room]]             | Core feature — launched                   |
 | [[Standard - Naming Architecture]] | Attendant tier fully activated            |
-| [[Strategy - AI as Teammates]]     | Advancing to L3.5 — agents with authority |
+| [[Product Thesis - AI as Teammates]]     | Advancing to L3.5 — agents with authority |
 | [[Standard - Service Levels]]      | Attendant-level service activated         |
 | [[Primitive - System]]             | Extended with delegation profiles         |
 

--- a/docs/context-library/releases/Release - The Attendants.md
+++ b/docs/context-library/releases/Release - The Attendants.md
@@ -84,13 +84,13 @@ The builder stops doing everything alone. Attendant agents — specialist AI wor
 
 ## AFFECTED LIBRARY CARDS
 
-| Card                               | How It's Affected                         |
-| ---------------------------------- | ----------------------------------------- |
-| [[Room - Roster Room]]             | Core feature — launched                   |
-| [[Standard - Naming Architecture]] | Attendant tier fully activated            |
-| [[Product Thesis - AI as Teammates]]     | Advancing to L3.5 — agents with authority |
-| [[Standard - Service Levels]]      | Attendant-level service activated         |
-| [[Primitive - System]]             | Extended with delegation profiles         |
+| Card                                 | How It's Affected                         |
+| ------------------------------------ | ----------------------------------------- |
+| [[Room - Roster Room]]               | Core feature — launched                   |
+| [[Standard - Naming Architecture]]   | Attendant tier fully activated            |
+| [[Product Thesis - AI as Teammates]] | Advancing to L3.5 — agents with authority |
+| [[Standard - Service Levels]]        | Attendant-level service activated         |
+| [[Primitive - System]]               | Extended with delegation profiles         |
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaced `rationale/strategies/` with `rationale/product-thesis/`, transforming 3 Strategy cards into Product Thesis (Plank) cards
- Authored 2 new cards: Problem Thesis (Organizational Life) and Solution Thesis (The Organized Life)
- Updated ~100 files: wikilinks, WHY label prefixes, prose references, meta files, and agent/skill definitions across the entire Context Library
- Removed dangling `[[Self-Determination Theory]]` wikilink references

## Test plan

- [x] Conan downstream sync (Job 9) verified all wikilinks resolve
- [x] Conan verification pass confirmed no stale Strategy references remain
- [x] Prettier formatting passes
- [x] All 5 Product Thesis cards exist with correct structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)